### PR TITLE
Next draft

### DIFF
--- a/nieper/rbtree.scm
+++ b/nieper/rbtree.scm
@@ -193,6 +193,18 @@
 	    (acc (loop acc b)))
 	 acc)))))
 
+(define (tree-fold/reverse proc seed tree)
+  (let loop ((acc seed) (tree tree))
+    (tree-match tree
+      ((black)
+       acc)
+      ((node _ a x b)
+       (let*
+	   ((acc (loop acc b))
+	    (acc (proc (item-key x) (item-value x) acc))
+	    (acc (loop acc a)))
+	 acc)))))
+
 (define (tree-for-each proc tree)
   (tree-fold (lambda (key value acc)
 	       (proc key value))
@@ -255,6 +267,30 @@
 		 (values (op (node c a x b)) ret op)))))))
       
     (values (blacken tree) ret)))
+
+(define (tree-key-successor comparator tree obj failure)
+  (let loop ((return failure) (tree tree))
+    (tree-match tree
+      ((black)
+       (return))
+      ((node _ a x b)
+       (let ((key (item-key x)))
+	 (comparator-if<=> comparator obj key
+			   (loop return b)
+			   (loop return b)
+			   (loop (lambda () key) a)))))))
+
+(define (tree-key-predecessor comparator tree obj failure)
+  (let loop ((return failure) (tree tree))
+    (tree-match tree
+      ((black)
+       (return))
+      ((node _ a x b)
+       (let ((key (item-key x)))
+	 (comparator-if<=> comparator obj key
+			   (loop (lambda () key) b)
+			   (loop return a)
+			   (loop return a)))))))
 
 ;;; Helper procedures for deleting and balancing
 

--- a/nieper/rbtree.scm
+++ b/nieper/rbtree.scm
@@ -275,7 +275,7 @@
        (return))
       ((node _ a x b)
        (let ((key (item-key x)))
-	 (comparator-if<=> comparator obj key
+	 (comparator-if<=> comparator key obj
 			   (loop return b)
 			   (loop return b)
 			   (loop (lambda () key) a)))))))
@@ -287,10 +287,101 @@
        (return))
       ((node _ a x b)
        (let ((key (item-key x)))
-	 (comparator-if<=> comparator obj key
+	 (comparator-if<=> comparator key obj
 			   (loop (lambda () key) b)
 			   (loop return a)
 			   (loop return a)))))))
+
+(define (tree-map proc tree)
+  (let loop ((tree tree))
+    (tree-match tree
+      ((black)
+       (black))
+      ((node c a x b)
+       (receive (key value)
+	   (proc (item-key x) (item-value x))
+	 (node c (loop a) (make-item key value) (loop b)))))))
+
+(define (tree-catenate tree1 pivot-key pivot-value tree2)
+  (let ((pivot (make-item pivot-key pivot-value))
+	(height1 (black-height tree1))
+	(height2 (black-height tree2)))
+    (cond
+     ((= height1 height2)
+      (black tree1 pivot tree2))
+     ((< height1 height2)
+      (blacken
+       (let loop ((tree tree2) (depth (- height2 height1)))
+	 (if (zero? depth)
+	     (red tree1 pivot tree)
+	     (balance (node (loop (left tree) (- depth 1)) (item tree) (right tree)))))))
+     (else
+      (blacken
+       (let loop ((tree tree1) (depth (- height1 height2)))
+	 (if (zero? depth)
+	     (red tree pivot tree2)
+	     (balance (node (right tree) (item tree) (loop (right tree) (- depth 1)))))))))))
+
+(define (tree-split comparator tree obj)
+  (let loop ((tree1 (black))
+	     (tree2 (black))
+	     (pivot1 #f)
+	     (pivot2 #f)
+	     (tree tree))
+    (tree-match tree
+      ((black)
+       (let ((tree1 (catenate-left tree1 pivot1 (black)))
+	     (tree2 (catenate-right (black) pivot2 tree2)))
+	 (values tree1 tree1 (black) tree2 tree2)))
+      ((node _ a x b)
+       (comparator-if<=> comparator obj (item-key x)
+			 (loop tree1
+			       (catenate-right b pivot2 tree2)
+			       pivot1
+			       x
+			       a)
+			 (let* ((tree1 (catenate-left tree1 pivot1 a))
+				(tree1+ (catenate-left tree1 x (black)))
+				(tree2 (catenate-right b pivot2 tree2))
+				(tree2+ (catenate-right (black) x tree2)))
+			   (values tree1 tree1+ (black (black) x (black)) tree2+ tree2))
+			 (loop (catenate-left tree1 pivot1 a)
+			       tree2
+			       x
+			       pivot2
+			       b))))))
+
+(define (catenate-left tree1 item tree2)
+  (if item
+      (tree-catenate tree1 (item-key item) (item-value item) tree2)
+      tree2))
+
+(define (catenate-right tree1 item tree2)
+  (if item
+      (tree-catenate tree1 (item-key item) (item-value item) tree2)
+      tree1))
+
+(define (black-height tree)
+  (let loop ((tree tree))
+    (tree-match tree
+      ((black)
+       0)
+      ((node red a x b)
+       (loop b))
+      ((node black a x b)
+       (+ 1 (loop b))))))
+
+(define (left-tree tree depth)
+  (let loop ((parent #f) (tree tree) (depth depth))
+    (if (zero? depth)
+	(values parent tree)
+	(loop tree (left tree) (- depth 1)))))
+
+(define (right-tree tree depth)
+  (let loop ((parent #f) (tree tree) (depth depth))
+    (if (zero? depth)
+	(values parent tree)
+	(loop tree (right tree) (- depth 1)))))
 
 ;;; Helper procedures for deleting and balancing
 

--- a/nieper/rbtree.sld
+++ b/nieper/rbtree.sld
@@ -21,7 +21,8 @@
 ;; SOFTWARE.
 
 (define-library (nieper rbtree)
-  (export make-tree tree-search tree-for-each tree-fold tree-generator)
+  (export make-tree tree-search tree-for-each tree-fold tree-fold/reverse tree-generator
+	  tree-key-predecessor tree-key-successor)
   (import (scheme base)
 	  (scheme case-lambda)
 	  (srfi 2)

--- a/nieper/rbtree.sld
+++ b/nieper/rbtree.sld
@@ -22,7 +22,8 @@
 
 (define-library (nieper rbtree)
   (export make-tree tree-search tree-for-each tree-fold tree-fold/reverse tree-generator
-	  tree-key-predecessor tree-key-successor)
+	  tree-key-predecessor tree-key-successor
+	  tree-map tree-catenate tree-split)
   (import (scheme base)
 	  (scheme case-lambda)
 	  (srfi 2)

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -337,6 +337,7 @@ is <code>eq?</code>, <code>eqv?</code>, <code>equal?</code>, <code>string=?</cod
       <code>mapping-range&gt;!</code>,
       <code>mapping-range&lt;=!</code>,
       <code>mapping-range&gt;=!</code>,
+      <code>mapping-split</code>,
       <code>mapping-catenate</code>,
       <code>mapping-catenate!</code>,
       <code>mapping-map/monotone</code>,
@@ -723,7 +724,7 @@ values in the mapping <code><em>mapping</em></code>.  The two lists are
 consistently ordered,  so that keys can be matched to their corresponding values.
 </p>
 
-<p>If <code>mapping-values</code> is imported from <code>(srfi 146
+<p>If <code>mapping-entries</code> is imported from <code>(srfi 146
     ordered)</code>, the lists is returned in order:  They are ordered
   according to the ordering of the keys.
 </p>
@@ -1038,6 +1039,19 @@ association.</i></p>
 associations of the <code><em>mapping</em></code> whose keys are equal
 to, less than, greater than, less than or equal to, or greater than or
 equal to <code><em>obj</em></code>.
+</p>
+
+<p><code>(mapping-split <em>mapping</em> <em>obj</em>)</code></p>
+
+<p>
+  Returns five values, equivalent to the results of invoking
+  <code>(mapping-range&lt; <em>mapping</em> <em>obj</em>)</code>,
+  <code>(mapping-range&lt;= <em>mapping</em> <em>obj</em>)</code>,
+  <code>(mapping-range= <em>mapping</em> <em>obj</em>)</code>,
+  <code>(mapping-range&gt;= <em>mapping</em> <em>obj</em>)</code>,
+  and
+  <code>(mapping-range&gt; <em>mapping</em> <em>obj</em>)</code>, but
+  may be more efficient.
 </p>
 
 <p><code>(mapping-catenate <em>mapping</em><sub>1</sub> <em>key</em> <em>value</em>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -229,20 +229,12 @@ is <code>eq?</code>, <code>eqv?</code>, <code>equal?</code>, <code>string=?</cod
 <p>
   (Scheme code which would be more performant/more natural with
   ordering procedures instead of hash functions, would change the
-  order of the two <cond-expand>-clauses.)
+  order of the two <code>&lt;cond-expand&gt;</code>-clauses.)
 </p>
 
-<p>As an author using SRFI 113 faces the same problems, any
-  implementation of SRFI 146 that also implements SRFI 113 should
-  implement its interface at least also under the <code>(srfi 113
-  ordered)</code> or <code>(srfi 113 hash)</code> namespace, depending
-  on which kind of comparators are supported (procedures exported
-  under <code>(srfi 113 ordered)</code> should respect the ordering
-  where it makes sense; see below).  (As SRFI 113 is also known
-  as <code>(scheme set)</code> in R7RS-large, the same recommendation
-  holds for <code>(scheme set ordered)</code> and <code>(scheme set
-  hash)</code>, should this SRFI become a part of a later Scheme
-  standard based on R7RS.)
+<p>It is left to a future SRFI that will update SRFI 113 to provide an
+  analogous addition to <code>(scheme set)</code>, <em>i.e.</em> to
+  specify <code>(scheme set hash)</code> and <code>(scheme set ordered)</code>.
 </p>
 
 <h2 id="index">Index</h2>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -1119,8 +1119,8 @@ many valuable comments which helped to improve this proposal.
 Some wording from SRFI 113 and SRFI 125 has been copied <i> mutatis mutandis</i>.
 </p>
 
-<h1>Copyright</h1>
-Copyright (C) Marc Nieper-Wi&szlig;kirchen (2016).  All Rights Reserved. 
+<h1>Copyright</h1> Copyright (C) Marc Nieper-Wi&szlig;kirchen (2016,
+2017).  All Rights Reserved.
 
 <p>
   Permission is hereby granted, free of charge, to any person

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -337,7 +337,10 @@ is <code>eq?</code>, <code>eqv?</code>, <code>equal?</code>, <code>string=?</cod
       <code>mapping-range&gt;!</code>,
       <code>mapping-range&lt;=!</code>,
       <code>mapping-range&gt;=!</code>,
+      <code>mapping-catenate</code>,
+      <code>mapping-catenate!</code>,
       <code>mapping-map/monotone</code>,
+      <code>mapping-map/monotone!</code>,
       <code>mapping-fold/reverse</code>
       </p>
   </li>
@@ -1016,8 +1019,8 @@ the thunk <code><em>failure</em></code>.
 <p><code>(mapping-range&gt;= <em>mapping</em> <em>obj</em>)</code></p>
 
 <p>Returns a mapping containing only the associations of
-the <code><em>mapping</em></code> whose keys are equal to/less
-than/greater than/less than or equal to/greater than or equal
+the <code><em>mapping</em></code> whose keys are equal to, less
+than, greater than, less than or equal to, or greater than or equal
   to <code><em>obj</em></code>.
 </p>
 
@@ -1031,10 +1034,35 @@ association.</i></p>
 <p><code>(mapping-range&lt;=! <em>mapping</em> <em>obj</em>)</code></p>
 <p><code>(mapping-range&gt;=! <em>mapping</em> <em>obj</em>)</code></p>
 
-<p>Linear update procedures returning a mapping containing only the associations of
-the <code><em>mapping</em></code> whose keys are equal to/less
-than/greater than/less than or equal to/greater than or equal
-  to <code><em>obj</em></code>.
+<p>Linear update procedures returning a mapping containing only the
+associations of the <code><em>mapping</em></code> whose keys are equal
+to, less than, greater than, less than or equal to, or greater than or
+equal to <code><em>obj</em></code>.
+</p>
+
+<p><code>(mapping-catenate <em>mapping</em><sub>1</sub> <em>key</em> <em>value</em>
+    <em>mapping</em></sub>2</sub>)</code></p>
+
+<p>
+Returns a newly allocated mapping using the
+comparator <code><em>comparator</em></code> whose set of associations
+is the union of the sets of associations of the
+mapping <code><em>mapping</em><sub>1</sub></code>,
+the association mapping <code><em>key</em></code> to
+<code><em>value</em></code>, and the associations of
+<code><em>mapping</em><sub>2</sub></code>.  It is an error if the keys
+contained in <code><em>mapping</em><sub>1</sub></code> in their
+natural order, the key <em>key</em>, and the keys contained
+in <code><em>mapping</em><sub>2</sub></code> in their natural order
+(in that order) do not form a strictly monotone sequence with respect
+to the ordering of <code><em>comparator</em></code>.
+</p>
+
+<p><code>(mapping-catenate! <em>mapping1</em> <em>key</em> <em>value</em> <em>mapping2</em>)</code></p>
+
+<p>The <code>mapping-map/monotone!</code> procedure is the same
+as <code>mapping-map/monotone</code>, except that it is permitted to mutate and
+return one of the <code><em>mapping</em></code>s rather than allocating a new mapping.
 </p>
 
 <p><code>(mapping-map/monotone <em>proc</em> <em>comparator</em> <em>mapping</em>)</code></p>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -1021,6 +1021,10 @@ than/greater than/less than or equal to/greater than or equal
   to <code><em>obj</em></code>.
 </p>
 
+<p><i>Note: Note that since keys in mappings are
+unique, <code>mapping-range=</code> returns a map with at most one
+association.</i></p>
+
 <p><code>(mapping-range=! <em>mapping</em> <em>obj</em>)</code></p>
 <p><code>(mapping-range&lt!; <em>mapping</em> <em>obj</em>)</code></p>
 <p><code>(mapping-range&gt;! <em>mapping</em> <em>obj</em>)</code></p>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -145,7 +145,6 @@ side effects, depending upon the details of what is the most efficient
   mapping1) ; mapping1 = {a&map;1,b&map;2,c&map;3} or mapping1 = {a&map;1,b&map;2,c&map;3;d&map;4}
 </pre>
 
-
 <p>However, this is well-defined:</p>
 
 <pre>
@@ -232,6 +231,12 @@ is <code>eq?</code>, <code>eqv?</code>, <code>equal?</code>, <code>string=?</cod
   order of the two <code>&lt;cond-expand&gt;</code>-clauses.)
 </p>
 
+<p>A number of additional operation with mappings that make only sense
+  when the keys are ordered (see below) are exported from
+  the <code>(srfi 146 ordered)</code> namespace, but neither from <code>(srfi 146)</code>, nor
+  <code>(srfi 146 hash)</code>.
+</p>
+
 <p>It is left to a future SRFI that will update SRFI 113 to provide an
   analogous addition to <code>(scheme set)</code>, <em>i.e.</em> to
   specify <code>(scheme set hash)</code> and <code>(scheme set ordered)</code>.
@@ -315,6 +320,28 @@ is <code>eq?</code>, <code>eqv?</code>, <code>equal?</code>, <code>string=?</cod
     </p>
   </li>
 
+  <li><p><a href="#Additionalproceduresformappingswithorderedkeys">Addition
+	procedures for mappings with ordered keys</a>:
+      <code>mapping-min-key</code>,
+      <code>mapping-max-key</code>, <code>mapping-min-value</code>.
+      <code>mapping-max-value</code>,
+      <code>mapping-key-predecessor</code>,
+      <code>mapping-key-successor</code>,
+      <code>mapping-range=</code>,
+      <code>mapping-range&lt;</code>,
+      <code>mapping-range&gt;</code>,
+      <code>mapping-range&lt;=</code>,
+      <code>mapping-range&gt;=</code>,
+      <code>mapping-range=!</code>,
+      <code>mapping-range&lt;!</code>,
+      <code>mapping-range&gt;!</code>,
+      <code>mapping-range&lt;=!</code>,
+      <code>mapping-range&gt;=!</code>,
+      <code>mapping-map/monotone</code>,
+      <code>mapping-fold/reverse</code>
+      </p>
+  </li>
+  
   <li>
     <p><a href="#Comparators">Comparators</a>:
       <code>mapping-comparator</code>
@@ -945,6 +972,91 @@ mappings by taking the difference between the first mapping and the union of
 the others.  Symmetric difference is not extended beyond two mappings.
 In case of duplicate keys (in the sense of the equality predicate), associations
 in the result mapping are drawn from the first mapping in which they appear.
+</p>
+
+<h2 id="Additionalproceduresformappingswithorderedkeys">Addition
+  procedures for mappings with ordererd keys</h2>
+
+<p>The following procedures are only exported by the <code>(srfi 146
+    ordered)</code> library (and, if applicable, by <code>(scheme mappings
+    ordered)</code>).
+</p>
+
+<p><code>(mapping-min-key <em>mapping</em>)</code></p>
+<p><code>(mapping-max-key <em>mapping</em>)</code></p>
+
+<p>Returns the least/greatest key contained in the mapping <code><em>mapping</em></code>.  It is an error for
+  <code><em>mapping</em></code> to be empty.
+</p>
+
+<p><code>(mapping-min-value <em>mapping</em>)</code></p>
+<p><code>(mapping-max-value <em>mapping</em>)</code></p>
+
+<p>Returns the value associated with the least/greatest key contained
+  in the mapping <code><em>mapping</em></code>.  It is an error
+  for <code><em>mapping</em></code> to be empty.</p>
+
+<p><i>Note: It does not make sense to ask for the least/greatest value
+contained in <code><em>mapping</em></code> because the values have no specified
+order.</i></p>
+
+<p><code>(mapping-key-predecessor <em>mapping</em> <em>obj</em> <em>failure</em>)</code></p>
+<p><code>(mapping-key-successor <em>mapping</em> <em>obj</em> <em>failure</em>)</code></p>
+<p>Returns the key contained in the mapping <code><em>mapping</em></code> that
+immediately precedes/succeeds <code><em>obj</em></code> in the mapping's order of
+keys.  If no such key is contained in <code><em>mapping</em></code>
+(because <code><em>obj</em></code> is the minimum/maximum key, or
+because <code><em>mapping</em></code> is empty), returns the result of tail-calling
+the thunk <code><em>failure</em></code>.
+
+<p><code>(mapping-range= <em>mapping</em> <em>obj</em>)</code></p>
+<p><code>(mapping-range&lt; <em>mapping</em> <em>obj</em>)</code></p>
+<p><code>(mapping-range&gt; <em>mapping</em> <em>obj</em>)</code></p>
+<p><code>(mapping-range&lt;= <em>mapping</em> <em>obj</em>)</code></p>
+<p><code>(mapping-range&gt;= <em>mapping</em> <em>obj</em>)</code></p>
+
+<p>Returns a mapping containing only the associations of
+the <code><em>mapping</em></code> whose keys are equal to/less
+than/greater than/less than or equal to/greater than or equal
+  to <code><em>obj</em></code>.
+</p>
+
+<p><code>(mapping-range=! <em>mapping</em> <em>obj</em>)</code></p>
+<p><code>(mapping-range&lt!; <em>mapping</em> <em>obj</em>)</code></p>
+<p><code>(mapping-range&gt;! <em>mapping</em> <em>obj</em>)</code></p>
+<p><code>(mapping-range&lt;=! <em>mapping</em> <em>obj</em>)</code></p>
+<p><code>(mapping-range&gt;=! <em>mapping</em> <em>obj</em>)</code></p>
+
+<p>Linear update procedures returning a mapping containing only the associations of
+the <code><em>mapping</em></code> whose keys are equal to/less
+than/greater than/less than or equal to/greater than or equal
+  to <code><em>obj</em></code>.
+</p>
+
+<p><code>(mapping-map/monotone <em>proc</em> <em>comparator</em> <em>mapping</em>)</code></p>
+
+<p>Equivalent
+to <code>(mapping-map <em>proc</em> <em>comparator</em> <em>mapping</em>)</code>,
+but it is an error if <em>proc</em> does not induce a strictly
+monotone mapping between the keys with respect to the ordering of the
+comparator of <code><em>mapping</em></code> and the ordering
+of <code><em>comparator</em></code>.  Maybe be implemented more
+efficiently than <code>mapping-map</code>.
+</p>
+
+<p><code>(mapping-map/monotone! <em>proc</em> <em>comparator</em> <em>mapping</em>)</code></p>
+
+<p>The <code>mapping-map/monotone!</code> procedure is the same
+as <code>mapping-map/monotone</code>, except that it is permitted to mutate and
+return the <code><em>mapping</em></code> argument rather than allocating a new mapping.
+</p>
+
+<p><code>(mapping-fold/reverse <em>proc</em> <em>nil</em> <em>mapping</em>)</code></p>
+
+<p>Equivalent
+to <code>(mapping-fold <em>proc</em> <em>nil</em> <em>mapping</em>)</code>
+except that the associations are processed in reverse order with
+respect to the natural ordering of the keys.
 </p>
 
 <h2 id="Comparators">Comparators</h2>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -974,8 +974,8 @@ In case of duplicate keys (in the sense of the equality predicate), associations
 in the result mapping are drawn from the first mapping in which they appear.
 </p>
 
-<h2 id="Additionalproceduresformappingswithorderedkeys">Addition
-  procedures for mappings with ordererd keys</h2>
+<h2 id="Additionalproceduresformappingswithorderedkeys">Additional
+procedures for mappings with ordererd keys</h2>
 
 <p>The following procedures are only exported by the <code>(srfi 146
     ordered)</code> library (and, if applicable, by <code>(scheme mappings

--- a/srfi/145.scm
+++ b/srfi/145.scm
@@ -28,12 +28,4 @@
     ((assume . _)
      (syntax-error "invalid assume syntax"))))
 
-(define-syntax assume-type
-  (syntax-rules ()
-    ((assume-type pred expr)
-     (unless (pred expr)
-       (fatal-error "not of expected type" (quote pred) expr)))
-    ((assume-type . _)
-     (syntax-error "invalid assume-type syntax"))))
-
 (define fatal-error error)

--- a/srfi/145.sld
+++ b/srfi/145.sld
@@ -21,6 +21,6 @@
 ;; SOFTWARE.
 
 (define-library (srfi 145)
-  (export fatal-error assume assume-type)
+  (export assume)
   (import (scheme base))
   (include "145.scm"))

--- a/srfi/146.scm
+++ b/srfi/146.scm
@@ -1,4 +1,5 @@
-;; Copyright (C) Marc Nieper-Wißkirchen (2016).  All Rights Reserved. 
+;; Copyright (C) Marc Nieper-Wißkirchen (2016, 2017).  All Rights
+;; Reserved.
 
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation

--- a/srfi/146.scm
+++ b/srfi/146.scm
@@ -29,7 +29,7 @@
   (tree mapping-tree))
 
 (define (make-empty-mapping comparator)
-  (assume-type comparator? comparator)
+  (assume (comparator? comparator))
   (%make-mapping comparator (make-tree)))
 
 ;;; Exported procedures
@@ -37,7 +37,7 @@
 ;; Constructors
 
 (define (mapping comparator . args)
-  (assume-type comparator? comparator)
+  (assume (comparator? comparator))
   (mapping-unfold null?
 	      (lambda (args)
 		(values (car args)
@@ -47,10 +47,10 @@
 	      comparator))
 
 (define (mapping-unfold stop? mapper successor seed comparator)
-  (assume-type procedure? stop?)
-  (assume-type procedure? mapper)
-  (assume-type procedure? successor)
-  (assume-type comparator? comparator)
+  (assume (procedure? stop?))
+  (assume (procedure? mapper))
+  (assume (procedure? successor))
+  (assume (comparator? comparator))
   (let loop ((mapping (make-empty-mapping comparator))
 	     (seed seed))
     (if (stop? seed)
@@ -63,11 +63,11 @@
 ;; Predicates
 
 (define (mapping-empty? mapping)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (not (mapping-any? (lambda (key value) #t) mapping)))
 
 (define (mapping-contains? mapping key)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (call/cc
    (lambda (return)
      (mapping-search mapping
@@ -78,8 +78,8 @@
 		   (return #t))))))
 
 (define (mapping-disjoint? mapping1 mapping2)
-  (assume-type mapping? mapping1)
-  (assume-type mapping? mapping2)
+  (assume (mapping? mapping1))
+  (assume (mapping? mapping2))
   (call/cc
    (lambda (return)
      (mapping-for-each (lambda (key value)
@@ -93,18 +93,18 @@
 (define mapping-ref
   (case-lambda
     ((mapping key)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      (mapping-ref mapping key (lambda ()
 			(fatal-error "mapping-ref: key not in mapping" key))))
     ((mapping key failure)
-     (assume-type mapping? mapping)
-     (assume-type procedure? failure)
+     (assume (mapping? mapping))
+     (assume (procedure? failure))
      (mapping-ref mapping key failure (lambda (value)
 				value)))
     ((mapping key failure success)
-     (assume-type mapping? mapping)
-     (assume-type procedure? failure)
-     (assume-type procedure? success)
+     (assume (mapping? mapping))
+     (assume (procedure? failure))
+     (assume (procedure? success))
      (call/cc
       (lambda (return)
 	(mapping-search mapping
@@ -115,13 +115,13 @@
 		      (return (success value)))))))))
 
 (define (mapping-ref/default mapping key default)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (mapping-ref mapping key (lambda () default)))
 
 ;; Updaters
 
 (define (mapping-set mapping . args)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (let loop ((args args)
 	     (mapping mapping))
     (if (null? args)
@@ -134,7 +134,7 @@
 (define mapping-set! mapping-set)
 
 (define (mapping-replace mapping key value)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (receive (mapping obj)
       (mapping-search mapping
 		  key
@@ -147,14 +147,14 @@
 (define mapping-replace! mapping-replace)
 
 (define (mapping-delete mapping . keys)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (mapping-delete-all mapping keys))
 
 (define mapping-delete! mapping-delete)
 
 (define (mapping-delete-all mapping keys)
-  (assume-type mapping? mapping)
-  (assume-type list? keys)
+  (assume (mapping? mapping))
+  (assume (list? keys))
   (fold (lambda (key mapping)
 	  (receive (mapping obj)
 	      (mapping-search mapping
@@ -169,8 +169,8 @@
 (define mapping-delete-all! mapping-delete-all)
 
 (define (mapping-intern mapping key failure)
-  (assume-type mapping? mapping)
-  (assume-type procedure? failure)
+  (assume (mapping? mapping))
+  (assume (procedure? failure))
   (call/cc
    (lambda (return)
      (mapping-search mapping
@@ -193,10 +193,10 @@
     (mapping-update mapping key updater failure (lambda (value)
 					  value)))
    ((mapping key updater failure success)
-    (assume-type mapping? mapping)
-    (assume-type procedure? updater)
-    (assume-type procedure? failure)
-    (assume-type procedure? success)
+    (assume (mapping? mapping))
+    (assume (procedure? updater))
+    (assume (procedure? failure))
+    (assume (procedure? success))
     (receive (mapping obj)
 	(mapping-search mapping
 		    key
@@ -214,9 +214,9 @@
 (define mapping-update!/default mapping-update/default)
 
 (define (mapping-search mapping key failure success)
-  (assume-type mapping? mapping)
-  (assume-type procedure? failure)
-  (assume-type procedure? success)
+  (assume (mapping? mapping))
+  (assume (procedure? failure))
+  (assume (procedure? success))
   (call/cc
    (lambda (return)
      (let*-values
@@ -239,15 +239,15 @@
 ;; The whole mapping
 
 (define (mapping-size mapping)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (mapping-count (lambda (key value)
 	       #t)
 	     mapping))
 
 (define (mapping-find predicate mapping failure)
-  (assume-type procedure? predicate)
-  (assume-type mapping? mapping)
-  (assume-type procedure? failure)
+  (assume (procedure? predicate))
+  (assume (mapping? mapping))
+  (assume (procedure? failure))
   (call/cc
    (lambda (return)
      (mapping-for-each (lambda (key value)
@@ -257,8 +257,8 @@
      (failure))))
 
 (define (mapping-count predicate mapping)
-  (assume-type procedure? predicate)
-  (assume-type mapping? mapping)
+  (assume (procedure? predicate))
+  (assume (mapping? mapping))
   (mapping-fold (lambda (key value count)
 	      (if (predicate key value)
 		  (+ 1 count)
@@ -266,8 +266,8 @@
 	    0 mapping))
 
 (define (mapping-any? predicate mapping)
-  (assume-type procedure? predicate)
-  (assume-type mapping? mapping)
+  (assume (procedure? predicate))
+  (assume (mapping? mapping))
   (call/cc
    (lambda (return)
      (mapping-for-each (lambda (key value)
@@ -277,37 +277,37 @@
      #f)))
 
 (define (mapping-every? predicate mapping)
-  (assume-type procedure? predicate)
-  (assume-type mapping? mapping)
+  (assume (procedure? predicate))
+  (assume (mapping? mapping))
   (not (mapping-any? (lambda (key value)
 		   (not (predicate key value)))
 		 mapping)))
 
 (define (mapping-keys mapping)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (reverse
    (mapping-fold (lambda (key value keys)
 		   (cons key keys))
 		 '() mapping)))
 
 (define (mapping-values mapping)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (reverse
    (mapping-fold (lambda (key value values)
 		   (cons value values))
 		 '() mapping)))
 
 (define (mapping-entries mapping)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (values (mapping-keys mapping)
 	  (mapping-values mapping)))
 
 ;; Mapping and folding
 
 (define (mapping-map proc comparator mapping)
-  (assume-type procedure? proc)
-  (assume-type comparator? comparator)
-  (assume-type mapping? mapping)
+  (assume (procedure? proc))
+  (assume (comparator? comparator))
+  (assume (mapping? mapping))
   (mapping-fold (lambda (key value mapping)
 	      (receive (key value)
 		  (proc key value)
@@ -316,18 +316,18 @@
 	    mapping))
 
 (define (mapping-for-each proc mapping)
-  (assume-type procedure? proc)
-  (assume-type mapping? mapping)
+  (assume (procedure? proc))
+  (assume (mapping? mapping))
   (tree-for-each proc (mapping-tree mapping)))
 
 (define (mapping-fold proc acc mapping)
-  (assume-type procedure? proc)
-  (assume-type mapping? mapping)
+  (assume (procedure? proc))
+  (assume (mapping? mapping))
   (tree-fold proc acc (mapping-tree mapping)))
 
 (define (mapping-map->list proc mapping)
-  (assume-type procedure? proc)
-  (assume-type mapping? mapping)
+  (assume (procedure? proc))
+  (assume (mapping? mapping))
   (reverse
    (mapping-fold (lambda (key value lst)
 		   (cons (proc key value) lst))
@@ -335,8 +335,8 @@
 		 mapping)))
 
 (define (mapping-filter predicate mapping)
-  (assume-type procedure? predicate)
-  (assume-type mapping? mapping)
+  (assume (procedure? predicate))
+  (assume (mapping? mapping))
   (mapping-fold (lambda (key value mapping)
 	      (if (predicate key value)
 		  (mapping-set mapping key value)
@@ -347,8 +347,8 @@
 (define mapping-filter! mapping-filter)
 
 (define (mapping-remove predicate mapping)
-  (assume-type procedure? predicate)
-  (assume-type mapping? mapping)
+  (assume (procedure? predicate))
+  (assume (mapping? mapping))
   (mapping-filter (lambda (key value)
 		(not (predicate key value)))
 	      mapping))
@@ -356,8 +356,8 @@
 (define mapping-remove! mapping-remove)
 
 (define (mapping-partition predicate mapping)
-  (assume-type procedure? predicate)
-  (assume-type mapping? mapping)
+  (assume (procedure? predicate))
+  (assume (mapping? mapping))
   (values (mapping-filter predicate mapping)
 	  (mapping-remove predicate mapping)))
 
@@ -366,19 +366,19 @@
 ;; Copying and conversion
 
 (define (mapping-copy mapping)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   mapping)
 
 (define (mapping->alist mapping)
-  (assume-type mapping? mapping)
+  (assume (mapping? mapping))
   (reverse
    (mapping-fold (lambda (key value alist)
 		   (cons (cons key value) alist))
 		 '() mapping)))
 
 (define (alist->mapping comparator alist)
-  (assume-type comparator? comparator)
-  (assume-type list? alist)
+  (assume (comparator? comparator))
+  (assume (list? alist))
   (mapping-unfold null?
 	      (lambda (alist)
 		(let ((key (caar alist))
@@ -389,8 +389,8 @@
 	      comparator))
 
 (define (alist->mapping! mapping alist)
-  (assume-type mapping? mapping)
-  (assume-type list? alist)
+  (assume (mapping? mapping))
+  (assume (list? alist))
   (fold (lambda (association mapping)
 	  (let ((key (car association))
 		(value (cdr association)))
@@ -403,7 +403,7 @@
 (define mapping=?
   (case-lambda
     ((comparator mapping)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      #t)
     ((comparator mapping1 mapping2) (%mapping=? comparator mapping1 mapping2))
     ((comparator mapping1 mapping2 . mappings)
@@ -416,24 +416,24 @@
 (define mapping<=?
   (case-lambda
     ((comparator mapping)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      #t)
     ((comparator mapping1 mapping2)
-     (assume-type comparator? comparator)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (comparator? comparator))
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (%mapping<=? comparator mapping1 mapping2))
     ((comparator mapping1 mapping2 . mappings)
-     (assume-type comparator? comparator)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (comparator? comparator))
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (and (%mapping<=? comparator mapping1 mapping2)
           (apply mapping<=? comparator mapping2 mappings)))))
 
 (define (%mapping<=? comparator mapping1 mapping2)
-  (assume-type comparator? comparator)
-  (assume-type mapping? mapping1)
-  (assume-type mapping? mapping2)
+  (assume (comparator? comparator))
+  (assume (mapping? mapping1))
+  (assume (mapping? mapping2))
   (let ((less? (comparator-ordering-predicate (mapping-key-comparator mapping1)))
 	(equality-predicate (comparator-equality-predicate comparator))
 	(gen1 (tree-generator (mapping-tree mapping1)))
@@ -461,70 +461,70 @@
 (define mapping>?
   (case-lambda
     ((comparator mapping)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      #t)
     ((comparator mapping1 mapping2)
-     (assume-type comparator? comparator)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (comparator? comparator))
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (%mapping>? comparator mapping1 mapping2))
     ((comparator mapping1 mapping2 . mappings)
-     (assume-type comparator? comparator)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (comparator? comparator))
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (and (%mapping>? comparator  mapping1 mapping2)
           (apply mapping>? comparator mapping2 mappings)))))
 
 (define (%mapping>? comparator mapping1 mapping2)
-  (assume-type comparator? comparator)
-  (assume-type mapping? mapping1)
-  (assume-type mapping? mapping2)
+  (assume (comparator? comparator))
+  (assume (mapping? mapping1))
+  (assume (mapping? mapping2))
   (not (%mapping<=? comparator mapping1 mapping2)))
 
 (define mapping<?
   (case-lambda
     ((comparator mapping)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      #t)
     ((comparator mapping1 mapping2)
-     (assume-type comparator? comparator)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (comparator? comparator))
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (%mapping<? comparator mapping1 mapping2))
     ((comparator mapping1 mapping2 . mappings)
-     (assume-type comparator? comparator)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (comparator? comparator))
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (and (%mapping<? comparator  mapping1 mapping2)
           (apply mapping<? comparator mapping2 mappings)))))
 
 (define (%mapping<? comparator mapping1 mapping2)
-     (assume-type comparator? comparator)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (comparator? comparator))
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (%mapping>? comparator mapping2 mapping1))
 
 (define mapping>=?
   (case-lambda
     ((comparator mapping)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      #t)
     ((comparator mapping1 mapping2)
-     (assume-type comparator? comparator)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (comparator? comparator))
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (%mapping>=? comparator mapping1 mapping2))
     ((comparator mapping1 mapping2 . mappings)
-     (assume-type comparator? comparator)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (comparator? comparator))
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (and (%mapping>=? comparator mapping1 mapping2)
           (apply mapping>=? comparator mapping2 mappings)))))
 
 (define (%mapping>=? comparator mapping1 mapping2)
-  (assume-type comparator? comparator)
-  (assume-type mapping? mapping1)
-  (assume-type mapping? mapping2)
+  (assume (comparator? comparator))
+  (assume (mapping? mapping1))
+  (assume (mapping? mapping2))
   (not (%mapping<? comparator mapping1 mapping2)))
 
 ;; Set theory operations
@@ -573,72 +573,72 @@
 (define mapping-union
   (case-lambda
     ((mapping)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      mapping)
     ((mapping1 mapping2)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (%mapping-union mapping1 mapping2))
     ((mapping1 mapping2 . mappings)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (apply mapping-union (%mapping-union mapping1 mapping2) mappings))))
 (define mapping-union! mapping-union)
 
 (define mapping-intersection
   (case-lambda
     ((mapping)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      mapping)
     ((mapping1 mapping2)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (%mapping-intersection mapping1 mapping2))
     ((mapping1 mapping2 . mappings)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (apply mapping-intersection (%mapping-intersection mapping1 mapping2) mappings))))
 (define mapping-intersection! mapping-intersection)
 
 (define mapping-difference
   (case-lambda
     ((mapping)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      mapping)
     ((mapping1 mapping2)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (%mapping-difference mapping1 mapping2))
     ((mapping1 mapping2 . mappings)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (apply mapping-difference (%mapping-difference mapping1 mapping2) mappings))))
 (define mapping-difference! mapping-difference)
 
 (define mapping-xor
   (case-lambda
     ((mapping)
-     (assume-type mapping? mapping)
+     (assume (mapping? mapping))
      mapping)
     ((mapping1 mapping2)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (%mapping-xor mapping1 mapping2))
     ((mapping1 mapping2 . mappings)
-     (assume-type mapping? mapping1)
-     (assume-type mapping? mapping2)
+     (assume (mapping? mapping1))
+     (assume (mapping? mapping2))
      (apply mapping-xor (%mapping-xor mapping1 mapping2) mappings))))
 (define mapping-xor! mapping-xor)
 
 ;; Comparators
 
 (define (mapping-equality comparator)
-  (assume-type comparator? comparator)
+  (assume (comparator? comparator))
   (lambda (mapping1 mapping2)
     (mapping=? comparator mapping1 mapping2)))
 
 (define (mapping-ordering comparator)
-  (assume-type comparator? comparator)
+  (assume (comparator? comparator))
   (let ((value-equality (comparator-equality-predicate comparator))
 	(value-ordering (comparator-ordering-predicate comparator)))
     (lambda (mapping1 mapping2)

--- a/srfi/146.scm
+++ b/srfi/146.scm
@@ -329,11 +329,10 @@
 (define (mapping-map->list proc mapping)
   (assume (procedure? proc))
   (assume (mapping? mapping))
-  (reverse
-   (mapping-fold (lambda (key value lst)
-		   (cons (proc key value) lst))
-		 '()
-		 mapping)))
+  (mapping-fold/reverse (lambda (key value lst)
+			  (cons (proc key value) lst))
+			'()
+			mapping))
 
 (define (mapping-filter predicate mapping)
   (assume (procedure? predicate))
@@ -633,6 +632,76 @@
 
 ;; Additional procedures for mappings with ordererd keys
 
+(define (mapping-min-key mapping)
+  (assume (mapping? mapping))
+  (call/cc
+   (lambda (return)
+     (mapping-fold (lambda (key value acc)
+		     (return key))
+		   #f mapping)
+     (error "mapping-min-key: empty map"))))
+
+(define (mapping-max-key mapping)
+  (assume (mapping? mapping))
+  (call/cc
+   (lambda (return)
+     (mapping-fold/reverse (lambda (key value acc)
+			     (return key))
+			   #f mapping)
+     (error "mapping-max-key: empty map"))))
+
+(define (mapping-min-value mapping)
+  (assume (mapping? mapping))
+  (call/cc
+   (lambda (return)
+     (mapping-fold (lambda (key value acc)
+		     (return value))
+		   #f mapping)
+     (error "mapping-min-value: empty map"))))
+
+(define (mapping-max-value mapping)
+  (assume (mapping? mapping))
+  (call/cc
+   (lambda (return)
+     (mapping-fold/reverse (lambda (key value acc)
+			     (return value))
+			   #f mapping)
+     (error "mapping-max-value: empty map"))))
+
+(define (mapping-key-predecessor mapping obj failure)
+  (assume (mapping? mapping))
+  (assume (procedure? failure))
+  (tree-key-predecessor (mapping-comparator mapping) (mapping-tree tree) obj failure))
+
+(define (mapping-key-successor mapping obj failure)
+  (assume (mapping? mapping))
+  (assume (procedure? failure))
+  (tree-key-successor (mapping-comparator mapping) (mapping-tree tree) obj failure))
+
+(define (mapping-range= map obj))
+
+(define mapping-range=! mapping-range=)
+(define mapping-range<! mapping-range<)
+(define mapping-range>! mapping-range>)
+(define mapping-range<=! mapping-range<=)
+(define mapping-range>=! mapping-range>=)
+
+(define mapping-map/monotone! mapping-map/monotone)
+
+(define (mapping-fold/reverse proc acc mapping)
+  (assume (procedure? proc))
+  (assume (mapping? mapping))
+  (tree-fold/reverse proc acc (mapping-tree mapping)))
+
+
+;mapping-min-key mapping-max-key
+;	mapping-min-value mapping-max-value
+;	mapping-key-predecessor mapping-key-successor
+;	mapping-range= mapping-range< mapping-range> mapping-range<= mapping-range>=
+;	mapping-range=! mapping-range<! mapping-range>! mapping-range<=! mapping-range>=!
+;	mapping-map/monotone mapping-map/monotone!
+;	mapping-fold/reverse
+	
 
 ;; Comparators
 

--- a/srfi/146.scm
+++ b/srfi/146.scm
@@ -631,6 +631,9 @@
      (apply mapping-xor (%mapping-xor mapping1 mapping2) mappings))))
 (define mapping-xor! mapping-xor)
 
+;; Additional procedures for mappings with ordererd keys
+
+
 ;; Comparators
 
 (define (mapping-equality comparator)

--- a/srfi/146/ordered.sld
+++ b/srfi/146/ordered.sld
@@ -31,7 +31,11 @@
 	  mapping-range=! mapping-range<! mapping-range>! mapping-range<=! mapping-range>=!
 	  mapping-map/monotone mapping-map/monotone!
 	  mapping-fold/reverse)
-  (import (srfi 146))
-  (import (srfi 145)
+  (import (scheme base)
+	  (scheme case-lambda)
+	  (srfi 1)
+	  (srfi 8)
+      	  (srfi 128)
+	  (srfi 145)
 	  (nieper rbtree))
-  (include "ordered.scm"))
+  (include "../146.scm"))

--- a/srfi/146/ordered.sld
+++ b/srfi/146/ordered.sld
@@ -1,4 +1,5 @@
-;; Copyright (C) Marc Nieper-Wißkirchen (2016).  All Rights Reserved. 
+;; Copyright (C) Marc Nieper-Wißkirchen (2016, 2017).  All Rights
+;; Reserved.
 
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation
@@ -23,4 +24,14 @@
 
 (define-library (srfi 146 ordered)
   (include-library-declarations "../146.exports.sld")
-  (import (srfi 146)))
+  (export mapping-min-key mapping-max-key
+	  mapping-min-value mapping-max-value
+	  mapping-key-predecessor mapping-key-successor
+	  mapping-range= mapping-range< mapping-range> mapping-range<= mapping-range>=
+	  mapping-range=! mapping-range<! mapping-range>! mapping-range<=! mapping-range>=!
+	  mapping-map/monotone mapping-map/monotone!
+	  mapping-fold/reverse)
+  (import (srfi 146))
+  (import (srfi 145)
+	  (nieper rbtree))
+  (include "ordered.scm"))

--- a/srfi/146/ordered.sld
+++ b/srfi/146/ordered.sld
@@ -29,6 +29,8 @@
 	  mapping-key-predecessor mapping-key-successor
 	  mapping-range= mapping-range< mapping-range> mapping-range<= mapping-range>=
 	  mapping-range=! mapping-range<! mapping-range>! mapping-range<=! mapping-range>=!
+	  mapping-split
+	  mapping-catenate mapping-catenate!
 	  mapping-map/monotone mapping-map/monotone!
 	  mapping-fold/reverse)
   (import (scheme base)


### PR DESCRIPTION
# Main Changes

* Remove requirements about SRFI 113 (postpone to future SRFI)
* Add additional procedures for maps with ordered keys
  - mapping-min-key
  - mapping-max-key
  - mapping-min-value
  - mapping-max-value
  - mapping-key-predecessor
  - mapping-key-successor
  - mapping-range=
  - mapping-range<
  - mapping-range>
  - mapping-range<=
  - mapping-range>=
  - mapping-range=!
  - mapping-range<!
  - mapping-range>!
  - mapping-range<=!
  - mapping-range>=!
  - mapping-split
  - mapping-catenate
  - mapping-catenate!
  - mapping-map/monotone
  - mapping-map/monotone!
  - mapping-fold/reverse