### PR TITLE
Addition of SRFI 113 implementation

### DIFF
--- a/nieper/rbtree.scm
+++ b/nieper/rbtree.scm
@@ -314,13 +314,15 @@
        (let loop ((tree tree2) (depth (- height2 height1)))
 	 (if (zero? depth)
 	     (red tree1 pivot tree)
-	     (balance (node (loop (left tree) (- depth 1)) (item tree) (right tree)))))))
+	     (balance
+	      (node (color node) (loop (left tree) (- depth 1)) (item tree) (right tree)))))))
      (else
       (blacken
        (let loop ((tree tree1) (depth (- height1 height2)))
 	 (if (zero? depth)
 	     (red tree pivot tree2)
-	     (balance (node (right tree) (item tree) (loop (right tree) (- depth 1)))))))))))
+	     (balance
+	      (node (color node) (left tree) (item tree) (loop (right tree) (- depth 1)))))))))))
 
 (define (tree-split comparator tree obj)
   (let loop ((tree1 (black))

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -1152,6 +1152,12 @@ in this SRFI is intimitely tied, the dependencies are trivial.)
 
 <a href="srfi/146.sld">Source for the reference implementation.</a>
 
+<p>For demonstration purposes and to have an implementation for sets
+and bags based on ordered comparators, this SRFI also includes a <a href="srfi/113.sld">new
+implementation of SRFI 113</a> as a thin
+layer over the procedures of SRFI 146.
+</p>
+  
 <h1>Acknowledgements</h1>
 
 <p>
@@ -1159,7 +1165,8 @@ Credit goes to John Cowan for SRFI 113 and SRFI 128, to Will Clinger
 and John Cowan for SRFI 125, and to Kevin Wortman for his
 immutable-maps-proposal.  Special credit also goes to Sudarshan S
 Chawathe for his careful reading of the drafts of this SRFI and his
-many valuable comments which helped to improve this proposal.
+many valuable comments which helped to improve this proposal, and to
+Jown Cowan for ideas on ordered mappings.
 </p>
 
 <p>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -409,11 +409,11 @@ The following three procedures, given a key, return the corresponding value.
 
 <p>Extracts the value associated to <code><em>key</em></code>
   in the mapping <code><em>mapping</em></code>, invokes the
-  procedure <code><em>success</em></code> on it, and returns its result;
+  procedure <code><em>success</em></code> in tail context on it, and returns its result;
   if <code><em>success</em></code> is not provided, then the value
   itself is return.  If <code><em>key</em></code> is not contained
   in <code><em>mapping</em></code> and <code><em>failure</em></code> is
-  supplied, then <code><em>failure</em></code> is invoked on no
+  supplied, then <code><em>failure</em></code> is invoked in tail context on no
   arguments and its result is return.  Otherwise, it is an error.
 </p>
 
@@ -661,7 +661,7 @@ Returns the number of associations in <em>mapping</em> as an exact integer.
   of the mapping <code><em>mapping</em></code> consisting of a key and value as two
   values such that <code><em>predicate</em></code> returns a true
   value when invoked with key and value as arguments, or the result of
-  invoking <code><em>failure</em></code> with no arguments if there is
+  tail-calling <code><em>failure</em></code> with no arguments if there is
   none.  There are no guarantees how many times and with which keys and values
   <code><em>predicate</em></code> is invoked, but see below:
 </p>

--- a/srfi/113.scm
+++ b/srfi/113.scm
@@ -1,0 +1,817 @@
+;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights
+;; Reserved.
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(define-record-type <set>
+  (make-set mapping)
+  set?
+  (mapping set-mapping))
+
+(define-record-type <bag>
+  (make-bag mapping)
+  bag?
+  (mapping bag-mapping))
+
+(define (make-empty-set comparator)
+  (make-set (mapping comparator)))
+
+(define (make-empty-bag comparator)
+  (make-bag (mapping comparator)))
+
+;; Constructors
+
+(define (set comparator . elements)
+  (assume (comparator? comparator))
+  (set-unfold null? car cdr elements comparator))
+
+(define (bag comparator . elements)
+  (assume (comparator? comparator))
+  (bag-unfold null? car cdr elements comparator))
+
+(define (set-unfold stop? mapper successor seed comparator)
+  (assume (procedure? stop?))
+  (assume (procedure? mapper))
+  (assume (procedure? successor))
+  (assume (comparator? comparator))
+  (make-set (mapping-unfold stop?
+			    (lambda (seed)
+			      (values (mapper seed) 1))
+			    successor
+			    seed
+			    comparator)))
+
+(define (bag-unfold stop? mapper successor seed comparator)
+  (assume (procedure? stop?))
+  (assume (procedure? mapper))
+  (assume (procedure? successor))
+  (assume (comparator? comparator))
+  (let loop ((bag (make-empty-bag comparator))
+	     (seed seed))
+    (if (stop? seed)
+	bag
+	(loop (bag-adjoin bag (mapper seed))
+	      (successor seed)))))
+
+;; Predicates
+
+(define (set-contains? set element)
+  (assume (set? set))
+  (mapping-contains? (set-mapping set) element))
+
+(define (bag-contains? bag element)
+  (assume (bag? bag))
+  (mapping-contains? (bag-mapping bag) element))
+
+(define (set-empty? set)
+  (assume (set? set))
+  (mapping-empty? (set-mapping set)))
+
+(define (bag-empty? bag)
+  (assume (bag? bag))
+  (mapping-empty? (bag-mapping bag)))
+
+(define (set-disjoint? set1 set2)
+  (assume (set? set1))
+  (assume (set? set2))
+  (mapping-disjoint? (set-mapping set1) (set-mapping set2)))
+
+(define (bag-disjoint? bag1 bag2)
+  (assume (bag? bag1))
+  (assume (bag? bag2))
+  (mapping-disjoint? (bag-mapping bag1) (bag-mapping bag2)))
+
+;; Accessors
+
+(define (set-member set element default)
+  (assume (set? set))
+  (call/cc
+   (lambda (return)
+     (mapping-search (set-mapping set)
+		     element
+		     (lambda (insert ignore)
+		       (return default))
+		     (lambda (old-element old-count update remove)
+		       (return old-element))))))
+
+(define (bag-member bag element default)
+  (assume (bag? bag))
+  (call/cc
+   (lambda (return)
+     (mapping-search (bag-mapping bag)
+		     element
+		     (lambda (insert ignore)
+		       (return default))
+		     (lambda (old-element old-count update remove)
+		       (return old-element))))))
+
+(define (set-element-comparator set)
+  (assume (set? set))
+  (mapping-key-comparator (set-mapping set)))
+
+(define (bag-element-comparator bag)
+  (assume (bag? bag))
+  (mapping-key-comparator (bag-mapping bag)))
+
+;; Updaters
+
+(define (set-adjoin set . elements)
+  (assume (set? set))
+  (make-set (fold (lambda (element mapping)
+		    (receive (mapping value)
+			(mapping-intern mapping element (lambda () 1))
+		      mapping))
+		  (set-mapping set) elements)))
+
+(define (bag-adjoin bag . elements)
+  (assume (bag? bag))
+  (fold (lambda (element bag)
+	  (bag-increment bag element 1))
+	bag elements))
+
+(define set-adjoin! set-adjoin)
+(define bag-adjoin! bag-adjoin)
+
+(define (set-replace set element)
+  (assume (set? set))
+  (make-set (mapping-replace (set-mapping set) element 1)))
+
+(define (bag-replace bag element)
+  (assume (bag? bag))
+  (receive (mapping obj)
+      (mapping-search (bag-mapping bag)
+		      element
+		      (lambda (insert ignore)
+			(ignore #f))
+		      (lambda (old-element count update remove)
+			(update element count #f)))
+    (make-bag mapping)))
+
+(define set-replace! set-replace)
+(define bag-replace! bag-replace)
+
+(define (set-delete set . elements)
+  (assume (set? set))
+  (set-delete-all set elements))
+
+(define (bag-delete bag . elements)
+  (assume (bag? bag))
+  (bag-delete-all bag elements))
+
+(define set-delete! set-delete)
+(define bag-delete! bag-delete)
+
+(define (set-delete-all set elements)
+  (assume (set? set))
+  (make-set (mapping-delete-all (set-mapping set) elements)))
+
+(define (bag-delete-all bag elements)
+  (assume (bag? bag))
+  (make-bag (mapping-delete-all (bag-mapping bag) elements)))
+
+(define set-delete-all! set-delete-all)
+(define bag-delete-all! bag-delete-all)
+
+(define (set-search! set element failure success)
+  (assume (set? set))
+  (assume (procedure? failure))
+  (assume (procedure? success))
+  (values set #f)
+  (call/cc
+   (lambda (return)
+     (receive (mapping obj)
+	 (mapping-search (set-mapping set)
+			 element
+			 (lambda (insert ignore)
+			   (failure (lambda (obj)
+				      (insert 1 obj))
+				    ignore))
+			 (lambda (old-element count update remove)
+			   (remove #f)
+			   (success old-element
+				    (lambda (new-element obj)
+				      (if (=? (set-element-comparator set)
+					      old-element
+					      new-element)
+					  (update new-element count obj)
+					  (return (set-adjoin (set-delete set old-element)
+							      new-element)
+						  obj)))
+				    remove)))
+       (values (make-set mapping) obj)))))
+
+(define (bag-search! bag element failure success)
+  (assume (bag? bag))
+  (assume (procedure? failure))
+  (assume (procedure? success))
+  (call/cc
+   (lambda (return)
+     (receive (mapping obj)
+	 (mapping-search (bag-mapping bag)
+			 element
+			 (lambda (insert ignore)
+			   (failure (lambda (obj)
+				      (insert 1 obj))
+				    ignore))
+			 (lambda (old-element old-count update remove)
+			   (success old-element
+				    (lambda (new-element obj)
+				      (if (=? (bag-element-comparator bag)
+					      old-element
+					      new-element)
+					  (update new-element old-count obj)
+					  (return (bag-adjoin (bag-delete bag old-element)
+							      new-element)
+						  obj)))
+				    (lambda (obj)
+				      (let ((new-count (- old-count 1)))
+					(if (zero? new-count)
+					    (remove obj)
+					    (update old-element new-count obj)))))))
+       (values (make-bag mapping) obj)))))
+
+;; The whole set
+
+(define (set-size set)
+  (assume (set? set))
+  (mapping-size (set-mapping set)))
+
+(define (bag-size bag)
+  (assume (bag? bag))
+  (mapping-fold (lambda (element count acc)
+		  (+ count acc))
+		0 (bag-mapping bag)))
+
+(define (set-find predicate set failure)
+  (assume (procedure? predicate))
+  (assume (set? set))
+  (assume (procedure? failure))
+  ((call/cc
+    (lambda (return-thunk) 
+      (receive (element count)
+	  (mapping-find (lambda (element count)
+			  (predicate element))
+			(set-mapping set)
+			(lambda () (return-thunk failure)))
+	(lambda () element))))))
+
+(define (bag-find predicate bag failure)
+  (assume (procedure? predicate))
+  (assume (bag? bag))
+  (assume (procedure? failure))
+  ((call/cc
+    (lambda (return-thunk) 
+      (receive (element count)
+	  (mapping-find (lambda (element count)
+			  (predicate element))
+			(bag-mapping bag)
+			(lambda () (return-thunk failure)))
+	(lambda () element))))))
+
+(define (set-count predicate set)
+  (assume (procedure? predicate))
+  (assume (set? set))
+  (mapping-count (lambda (element count)
+		   (predicate element))
+		 (set-mapping set)))
+
+(define (bag-count predicate bag)
+  (assume (procedure? predicate))
+  (assume (bag? bag))
+  (mapping-fold (lambda (element count acc)
+		  (if (predicate element)
+		      (+ count acc)
+		      acc))
+		0 (bag-mapping bag)))
+
+(define (set-any? predicate set)
+  (assume (procedure? predicate))
+  (assume (set? set))
+  (mapping-any? (lambda (element count)
+		  (predicate element))
+		(set-mapping set)))
+
+(define (bag-any? predicate bag)
+  (assume (procedure? predicate))
+  (assume (bag? bag))
+  (mapping-any? (lambda (element count)
+		  (predicate element))
+		(bag-mapping bag)))
+
+(define (set-every? predicate set)
+  (assume (procedure? predicate))
+  (assume (set? set))
+  (mapping-every? (lambda (element count)
+		    (predicate element))
+		  (set-mapping set)))
+
+(define (bag-every? predicate bag)
+  (assume (procedure? predicate))
+  (assume (bag? bag))
+  (mapping-every? (lambda (element count)
+		    (predicate element))
+		  (bag-mapping bag)))
+
+;; Mapping and folding
+
+(define (set-map proc comparator set)
+  (assume (procedure? proc))
+  (assume (comparator? comparator))
+  (assume (set? set))
+  (make-set (mapping-map (lambda (element count)
+			   (values (proc element)
+				   count))
+			 (set-element-comparator set)
+			 (set-mapping set))))
+
+(define (bag-map proc comparator bag)
+  (assume (procedure? proc))
+  (assume (comparator? comparator))
+  (assume (bag? bag))
+  (mapping-fold (lambda (element count bag)
+		  (let loop ((count count) (bag bag))
+		    (if (zero? count)
+			bag
+			(loop (- count 1) (bag-adjoin bag (proc element))))))
+		(make-empty-bag comparator) (bag-mapping bag)))
+
+(define (set-for-each proc set)
+  (assume (procedure? proc))
+  (assume (set? set))
+  (mapping-for-each (lambda (element count)
+		      (proc element))
+		    (set-mapping set)))
+
+(define (bag-for-each proc bag)
+  (assume (procedure? proc))
+  (assume (bag? bag))
+  (mapping-for-each (lambda (element count)
+		      (do ((count count (- count 1)))
+			  ((zero? count))
+			(proc element)))
+		    (bag-mapping bag)))
+
+(define (set-fold proc nil set)
+  (assume (procedure? proc))
+  (assume (set? set))
+  (mapping-fold (lambda (element count nil)
+		  (proc element nil))
+		nil (set-mapping set)))
+
+(define (bag-fold proc nil bag)
+  (assume (procedure? proc))
+  (assume (bag? bag))
+  (mapping-fold (lambda (element count acc)
+		  (let loop ((count count) (acc acc))
+		    (if (zero? count)
+			acc
+			(loop (- count 1) (proc element acc)))))
+		nil (bag-mapping bag)))
+
+(define (set-filter predicate set)
+  (assume (procedure? predicate))
+  (assume (set? set))
+  (make-set (mapping-filter (lambda (element count)
+			      (predicate element))
+			    (set-mapping set))))
+
+(define (bag-filter predicate bag)
+  (assume (procedure? predicate))
+  (assume (bag? bag))
+  (make-bag (mapping-filter (lambda (element count)
+			      (predicate element))
+			    (bag-mapping bag))))
+
+(define set-filter! set-filter)
+(define bag-filter! bag-filter)
+
+(define (set-remove predicate set)
+  (assume (procedure? predicate))
+  (assume (set? set))
+  (make-set (mapping-remove (lambda (element count)
+			      (predicate element))
+			    (set-mapping set))))
+
+(define (bag-remove predicate bag)
+  (assume (procedure? predicate))
+  (assume (bag? bag))
+  (make-bag (mapping-remove (lambda (element count)
+			      (predicate element))
+			    (bag-mapping bag))))
+
+(define set-remove! set-remove)
+(define bag-remove! bag-remove)
+
+(define (set-partition predicate set)
+  (assume (procedure? predicate))
+  (assume (set? set))
+  (receive (mapping1 mapping2)
+      (mapping-partition (lambda (element count)
+			(predicate element))
+			 (set-mapping set))
+    (values (make-set mapping1) (make-set mapping2))))
+
+(define (bag-partition predicate bag)
+  (assume (procedure? predicate))
+  (assume (bag? bag))
+  (receive (mapping1 mapping2)
+      (mapping-partition (lambda (element count)
+			(predicate element))
+			 (bag-mapping bag))
+    (values (make-bag mapping1) (make-bag mapping2))))
+
+(define set-partition! set-partition)
+(define bag-partition! bag-partition)
+
+;; Copying and conversion
+
+(define (set-copy set)
+  (assume (set? set))
+  set)
+
+(define (bag-copy bag)
+  (assume (bag? bag))
+  bag)
+
+(define (set->list set)
+  (assume (set? set))
+  (mapping-fold/reverse (lambda (element count lst)
+			  (cons element lst))
+			'() (set-mapping set)))
+
+(define (bag->list bag)
+  (assume (bag? bag))
+  (mapping-fold/reverse (lambda (element count lst)
+			  (let loop ((count count) (lst lst))
+			    (if (zero? count)
+				lst
+				(loop (- count 1)
+				      (cons element lst)))))
+			'() (bag-mapping bag)))
+
+(define (list->set comparator lst)
+  (assume (comparator? comparator))
+  (assume (list? lst))
+  (apply set comparator lst))
+
+(define (list->bag comparator lst)
+  (assume (comparator? comparator))
+  (assume (list? lst))
+  (apply bag comparator lst))
+
+(define (list->set! set lst)
+  (assume (set? set))
+  (assume (list? lst))
+  (apply set-adjoin set lst))
+
+(define (list->bag! bag lst)
+  (assume (bag? bag))
+  (assume (list? lst))
+  (apply bag-adjoin bag lst))
+
+;; Subsets
+
+(define (set=? set . sets)
+  (assume (set? set))
+  (apply mapping=? (make-eqv-comparator) (set-mapping set) (map set-mapping sets)))
+
+(define (bag=? bag . bags)
+  (assume (bag? bag))
+  (apply mapping=? (make-eqv-comparator) (bag-mapping bag) (map bag-mapping bags)))
+
+(define (set<? set . sets)
+  (assume (set? set))
+  (apply mapping<? (make-eqv-comparator) (set-mapping set) (map set-mapping sets)))
+
+(define (set>? set . sets)
+  (assume (set? set))
+  (apply mapping>? (make-eqv-comparator) (set-mapping set) (map set-mapping sets)))
+
+(define (set<=? set . sets)
+  (assume (set? set))
+  (apply mapping<=? (make-eqv-comparator) (set-mapping set) (map set-mapping sets)))
+
+(define (set>=? set . sets)
+  (assume (set? set))
+  (apply mapping>=? (make-eqv-comparator) (set-mapping set) (map set-mapping sets)))
+
+(define bag<=?
+  (case-lambda
+    ((bag)
+     (assume (bag? bag))
+     #t)
+    ((bag1 bag2)
+     (assume (bag? bag1))
+     (assume (bag? bag2))
+     (%bag<=? bag1 bag2))
+    ((bag1 bag2 . bags)
+     (assume (bag? bag1))
+     (assume (bag? bag2))
+     (and (%bag<=? bag1 bag2)
+          (apply bag<=? bag2 bags)))))
+
+(define (%bag<=? bag1 bag2)
+  (assume (bag? bag1))
+  (assume (bag? bag2))
+  (let ((less? (comparator-ordering-predicate (bag-element-comparator bag1)))
+	(gen1 (bag-generator bag1))
+	(gen2 (bag-generator bag2)))
+    (let loop ((item1 (gen1))
+	       (item2 (gen2)))
+      (cond
+       ((eof-object? item1)
+	#t)
+       ((eof-object? item2)
+	#f)
+       (else
+	(let ((key1 (car item1)) (value1 (cadr item1))
+	      (key2 (car item2)) (value2 (cadr item2)))
+	  (cond
+	   ((less? key1 key2)
+	    #f)
+	   ((less? key2 key1)
+	    (loop item1 (gen2)))
+	   ((<= value1 value2)
+	    (loop (gen1) (gen2)))
+	   (else
+	    #f))))))))
+
+(define bag>?
+  (case-lambda
+    ((bag)
+     (assume (bag? bag))
+     #t)
+    ((bag1 bag2)
+     (assume (bag? bag1))
+     (assume (bag? bag2))
+     (%bag>? bag1 bag2))
+    ((bag1 bag2 . bags)
+     (assume (bag? bag1))
+     (assume (bag? bag2))
+     (and (%bag>? bag1 bag2)
+          (apply bag>? bag2 bags)))))
+
+(define (%bag>? bag1 bag2)
+  (assume (bag? bag1))
+  (assume (bag? bag2))
+  (not (%bag<=? bag1 bag2)))
+
+(define bag<?
+  (case-lambda
+    ((bag)
+     (assume (bag? bag))
+     #t)
+    ((bag1 bag2)
+     (assume (bag? bag1))
+     (assume (bag? bag2))
+     (%bag<? bag1 bag2))
+    ((bag1 bag2 . bags)
+     (assume (bag? bag1))
+     (assume (bag? bag2))
+     (and (%bag<? bag1 bag2)
+          (apply bag<? bag2 bags)))))
+
+(define (%bag<? bag1 bag2)
+  (assume (bag? bag1))
+  (assume (bag? bag2))
+  (%bag>? bag2 bag1))
+
+(define bag>=?
+  (case-lambda
+    ((bag)
+     (assume (bag? bag))
+     #t)
+    ((bag1 bag2)
+     (assume (bag? bag1))
+     (assume (bag? bag2))
+     (%bag>=? bag1 bag2))
+    ((bag1 bag2 . bags)
+     (assume (bag? bag1))
+     (assume (bag? bag2))
+     (and (%bag>=? bag1 bag2)
+          (apply bag>=? bag2 bags)))))
+
+(define (%bag>=? bag1 bag2)
+  (assume (bag? bag1))
+  (assume (bag? bag2))
+  (not (%bag<? bag1 bag2)))
+
+(define (bag-generator bag)
+  (make-coroutine-generator
+   (lambda (yield)
+     (mapping-for-each (lambda item (yield item)) (bag-mapping bag)))))
+
+;; Set theory operations
+
+(define (set-union set . sets)
+  (assume (set? set))
+  (make-set (apply mapping-union (set-mapping set) (map set-mapping sets))))
+
+(define (set-intersection set . sets)
+  (assume (set? set))
+  (make-set (apply mapping-intersection (set-mapping set) (map set-mapping sets))))
+
+(define (set-difference set . sets)
+  (assume (set? set))
+  (make-set (apply mapping-difference (set-mapping set) (map set-mapping sets))))
+
+(define (set-xor set1 set2)
+  (assume (set? set1))
+  (assume (set? set2))  
+  (make-set (mapping-xor (set-mapping set1) (set-mapping set2))))
+
+(define set-union! set-union)
+(define set-intersection! set-intersection)
+(define set-difference! set-difference)
+(define set-xor! set-xor)
+
+(define (bag-union bag . bags)
+  (assume (bag? bag))
+  (fold (lambda (bag2 bag1)
+	  (mapping-fold (lambda (element count bag)
+			  (bag-update bag element (lambda (old-count) (max old-count count))))
+			bag1 (bag-mapping bag2)))
+	bag bags))
+
+(define (bag-intersection bag . bags)
+  (assume (bag? bag))
+  (fold (lambda (bag2 bag1)
+	  (%bag-intersection bag1 bag2))
+	bag bags))
+
+(define (%bag-intersection bag1 bag2)
+  (assume (bag? bag1))
+  (assume (bag? bag2))
+  (let ((less? (comparator-ordering-predicate (bag-element-comparator bag1)))
+	(gen1 (bag-generator bag1))
+	(gen2 (bag-generator bag2)))
+    (let loop ((item1 (gen1))
+	       (item2 (gen2))
+	       (bag (make-empty-bag (bag-element-comparator bag1))))
+      (cond
+       ((eof-object? item1)
+	bag)
+       ((eof-object? item2)
+	bag)
+       (else
+	(let ((key1 (car item1)) (count1 (cadr item1))
+	      (key2 (car item2)) (count2 (cadr item2)))
+	  (cond
+	   ((less? key1 key2)
+	    (loop (gen1) item2 bag))
+	   ((less? key2 key1)
+	    (loop item1 (gen2) bag))
+	   (else
+	    (loop (gen1) (gen2) (bag-increment bag key1 (min count1 count2)))))))))))
+
+(define (bag-difference bag . bags)
+  (assume (bag? bag))
+  (fold (lambda (bag2 bag1)
+	  (mapping-fold (lambda (element count bag)
+			  (bag-update bag element (lambda (old-count) (max 0 (- old-count count)))))
+			bag1 (bag-mapping bag2)))
+	bag bags))
+
+(define (bag-xor bag1 bag2)
+  (assume (bag? bag1))
+  (assume (bag? bag2))
+  (mapping-fold (lambda (element count bag)
+		  (bag-update bag element (lambda (old-count) (abs (- old-count count)))))
+		bag1 (bag-mapping bag2)))
+
+(define bag-union! bag-union)
+(define bag-intersection! bag-intersection)
+(define bag-difference! bag-difference)
+(define bag-xor! bag-xor)
+
+(define (bag-update bag element updater)
+  (receive (mapping obj)
+      (mapping-search (bag-mapping bag)
+		      element
+		      (lambda (insert ignore)
+			(let ((new-count (updater 0)))
+			  (if (zero? new-count)
+			      (ignore #f)
+			      (insert new-count #f))))
+		      (lambda (old-element old-count update remove)
+			(let ((new-count (updater old-count)))
+			  (if (zero? new-count)
+			      (remove #f)
+			      (update element new-count #f)))))
+    (make-bag mapping)))
+
+;; Additional bag procedures
+
+(define (bag-sum bag . bags)
+  (assume (bag? bag))
+  (if (null? bags)
+      bag
+      (mapping-fold (lambda (element count bag)
+		      (bag-update bag element (lambda (old-count) (+ old-count count))))
+		    bag (bag-mapping (car bags)))))
+
+(define bag-sum! bag-sum)
+
+(define (bag-product n bag)
+  (assume (not (negative? n)))
+  (assume (bag? bag))
+  (make-bag (mapping-map (lambda (element count)
+			   (values element (* n count)))
+			 (bag-element-comparator bag)
+			 (bag-mapping bag))))
+
+(define bag-product! bag-product)
+
+(define (bag-unique-size bag)
+  (assume (bag? bag))
+  (mapping-size (bag-mapping bag)))
+
+(define (bag-element-count bag element)
+  (assume (bag? bag))
+  (mapping-ref/default (bag-mapping bag) element 0))
+
+(define (bag-for-each-unique proc bag)
+  (assume (bag? bag))
+  (mapping-for-each proc (bag-mapping bag)))
+
+(define (bag-fold-unique proc nil bag)
+  (assume (procedure? proc))
+  (assume (bag? bag))
+  (mapping-fold proc nil (bag-mapping bag)))
+
+(define (bag-increment bag element count)
+  (assume (exact-integer? count))
+  (assume (bag? bag))
+  (bag-update bag element (lambda (old-count)
+			    (max 0 (+ count old-count)))))
+
+(define bag-increment! bag-increment)
+
+(define (bag-decrement! bag element count)
+  (assume (exact-integer? count))
+  (assume (bag? bag))
+  (bag-update bag element (lambda (old-count)
+			    (max 0 (- old-count count)))))
+
+(define (bag->set bag)
+  (assume (bag? bag))
+  (make-set (mapping-map (lambda (element count)
+			   (values element 1))
+			 (bag-element-comparator bag)
+			 (bag-mapping bag))))
+
+(define (set->bag set)
+  (assume (set? set))
+  (make-bag (set-mapping set)))
+
+(define (set->bag! bag set)
+  (set-fold (lambda (element bag)
+	      (bag-adjoin! bag element))
+	    bag set))
+
+(define (bag->alist bag)
+  (assume (bag? bag))
+  (mapping->alist (bag-mapping bag)))
+
+(define (alist->bag comparator alist)
+  (assume (comparator? comparator))
+  (assume (list? alist))
+  (make-bag (alist->mapping comparator alist)))
+
+;; Comparators
+
+(define mapping-ordering
+  (comparator-ordering-predicate (make-mapping-comparator (make-default-comparator))))
+
+(define (set-ordering set1 set2)
+  (mapping-ordering (set-mapping set1) (set-mapping set2)))
+
+(define (bag-ordering bag1 bag2)
+  (mapping-ordering (bag-mapping bag1) (bag-mapping bag2)))
+
+(define set-comparator
+  (make-comparator set? set=? set-ordering #f))
+
+(define bag-comparator
+  (make-comparator bag? bag=? bag-ordering #f))
+
+(comparator-register-default! set-comparator)
+(comparator-register-default! bag-comparator)

--- a/srfi/113.sld
+++ b/srfi/113.sld
@@ -1,0 +1,65 @@
+;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights
+;; Reserved.
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(define-library (srfi 113)
+  (export set set-unfold
+	  set? set-contains? set-empty? set-disjoint?
+	  set-member set-element-comparator
+	  set-adjoin set-adjoin! set-replace set-replace!
+	  set-delete set-delete! set-delete-all set-delete-all! set-search!
+	  set-size set-find set-count set-any? set-every?
+	  set-map set-for-each set-fold
+	  set-filter set-remove set-partition
+	  set-filter! set-remove! set-partition!
+	  set-copy set->list list->set list->set!
+	  set=? set<? set>? set<=? set>=?
+	  set-union set-intersection set-difference set-xor
+	  set-union! set-intersection! set-difference! set-xor!
+	  set-comparator
+	  bag bag-unfold
+	  bag? bag-contains? bag-empty? bag-disjoint?
+	  bag-member bag-element-comparator
+	  bag-adjoin bag-adjoin! bag-replace bag-replace!
+	  bag-delete bag-delete! bag-delete-all bag-delete-all! bag-search!
+	  bag-size bag-find bag-count bag-any? bag-every?
+	  bag-map bag-for-each bag-fold
+	  bag-filter bag-remove bag-partition
+	  bag-filter! bag-remove! bag-partition!
+	  bag-copy bag->list list->bag list->bag!
+	  bag=? bag<? bag>? bag<=? bag>=?
+	  bag-union bag-intersection bag-difference bag-xor
+	  bag-union! bag-intersection! bag-difference! bag-xor!
+	  bag-comparator
+	  bag-sum bag-sum! bag-product bag-product!
+	  bag-unique-size bag-element-count bag-for-each-unique bag-fold-unique
+	  bag-increment! bag-decrement! bag->set set->bag set->bag!
+	  bag->alist alist->bag)
+  (import (scheme base)
+	  (scheme case-lambda)
+	  (srfi 1)
+	  (srfi 8)
+	  (srfi 121)
+	  (srfi 128)
+	  (srfi 145)
+	  (srfi 146 ordered))
+  (include "113.scm"))

--- a/srfi/113/test.sld
+++ b/srfi/113/test.sld
@@ -1,0 +1,669 @@
+;; Copyright (C) Marc Nieper-Wißkirchen (2017).  All Rights
+;; Reserved.
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+
+;; Copyright (C) John Cowan (2015). All Rights Reserved.
+
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+
+(define-library (srfi 113 test)
+  (export run-tests)
+  (import (scheme base)
+	  (scheme char)
+	  (srfi 64)
+	  (srfi 128)
+	  (srfi 113))
+  (begin
+    (define number-comparator (make-default-comparator))
+    (define char-comparator (make-default-comparator))
+    (define eq-comparator (make-default-comparator))
+    (define eqv-comparator (make-default-comparator))
+    (define string-ci-comparator (make-comparator string? string-ci=? string-ci<? string-ci-hash))
+    (define default-comparator (make-default-comparator))
+
+    (define current-test-comparator (make-parameter equal?))
+    (define-syntax test
+      (syntax-rules ()
+	((test test-name ... expected test-expr)
+	 (test-assert test-name ... ((current-test-comparator) expected test-expr)))))
+    
+    (define (run-tests)
+      (test-begin "SRFI 113")
+
+      (test-group "sets"
+		  (define (big x) (> x 5))
+	
+		  (test-group "sets"
+			      (test-group "sets/simple"
+					  (define total 0)
+
+					  (define nums (set number-comparator))
+					  ;; nums is now {}
+					  (define syms (set eq-comparator 'a 'b 'c 'd))
+					  ;; syms is now {a, b, c, d}
+					  (define nums2 (set-copy nums))
+					  ;; nums2 is now {}
+					  (define syms2 (set-copy syms))
+					  ;; syms2 is now {a, b, c, d}
+					  (define esyms (set eq-comparator))
+					  ;; esyms is now {}
+
+					  (test-assert (set-empty? esyms))
+					  (test-assert (set? nums))
+					  (test-assert (set? syms))
+					  (test-assert (set? nums2))
+					  (test-assert (set? syms2))
+					  (test-assert (not (set? 'a)))
+					  (set! nums (set-adjoin! nums 2))
+					  (set! nums (set-adjoin! nums 3))
+					  (set! nums (set-adjoin! nums 4))
+					  (set! nums (set-adjoin! nums 4))
+					  ;; nums is now {2, 3, 4}
+					  (test-eq 4 (set-size (set-adjoin nums 5)))
+					  (test-eq 3 (set-size nums))
+					  (test-eq 3 (set-size (set-delete syms 'd)))
+					  (test-eq 2 (set-size (set-delete-all syms '(c d))))
+					  (test-eq 4 (set-size syms))
+					  (set! syms (set-adjoin! syms 'e 'f))
+					  ;; syms is now {a, b, c, d, e, f}
+					  (set! syms (set-delete-all! syms '(e f)))
+					  (test-eq 4 (set-size syms))
+					  ;; syms is now {a, b, c, d}
+					  (test-eq 0 (set-size nums2))
+					  (test-eq 4 (set-size syms2))
+					  (set! nums (set-delete! nums 2))
+					  ;; nums is now {3, 4}
+					  (test-eq 2 (set-size nums))
+					  (set! nums (set-delete! nums 1))
+					  (test-eq 2 (set-size nums))
+					  (set! nums2 (set-map (lambda (x) (* 10 x)) number-comparator nums))
+					  ;; nums2 is now {30, 40}
+					  (test-assert (set-contains? nums2 30))
+					  (test-assert (not (set-contains? nums2 3)))
+					  (set-for-each (lambda (x) (set! total (+ total x))) nums2)
+					  (test-eq 70 total)
+					  (test-eq 10 (set-fold + 3 nums))
+					  (set! nums (set eqv-comparator 10 20 30 40 50))
+					  ;; nums is now {10, 20, 30, 40, 50}
+					  (test-assert
+					      (set=? nums (set-unfold
+							   (lambda (i) (= i 0))
+							   (lambda (i) (* i 10))
+							   (lambda (i) (- i 1))
+							   5
+							   eqv-comparator)))
+					  (test-equal '(a) (set->list (set eq-comparator 'a)))
+					  (set! syms2 (list->set eq-comparator '(e f)))
+					  ;; syms2 is now {e, f}
+					  (test-eq 2 (set-size syms2))
+					  (test-assert (set-contains? syms2 'e))
+					  (test-assert (set-contains? syms2 'f))
+					  (set! syms2 (list->set! syms2 '(a b)))
+					  (test-eq 4 (set-size syms2))
+					  ) ; end sets/simple
+
+			      (test-group "sets/search"
+					  (define yam (set char-comparator #\y #\a #\m))
+					  (define (failure/insert insert ignore)
+					    (insert 1))
+					  (define (failure/ignore insert ignore)
+					    (ignore 2))
+					  (define (success/update element update remove)
+					    (update #\b 3))
+					  (define (success/remove element update remove)
+					    (remove 4))
+					  (define yam! (set char-comparator #\y #\a #\m #\!))
+					  (define bam (set char-comparator #\b #\a #\m))
+					  (define ym (set char-comparator #\y #\m))
+					  (define-values (set1 obj1)
+					    (set-search! (set-copy yam) #\! failure/insert error))
+					  (define-values (set2 obj2)
+					    (set-search! (set-copy yam) #\! failure/ignore error))
+					  (define-values (set3 obj3)
+					    (set-search! (set-copy yam) #\y error success/update))
+					  (define-values (set4 obj4)
+					    (set-search! (set-copy yam) #\a error success/remove))
+					  (test-assert (set=? yam! set1))
+					  (test-eqv 1 obj1)
+					  (test-assert (set=? yam set2))
+					  (test-eqv 2 obj2)
+					  (test-assert (set=? bam set3))
+					  (test-eqv 3 obj3)
+					  (test-assert (set=? ym set4))
+					  (test-eqv 4 obj4) ; end sets/search
+
+					  (test-group "sets/subsets"
+						      (define set2 (set number-comparator 1 2))
+						      (define other-set2 (set number-comparator 1 2))
+						      (define set3 (set number-comparator 1 2 3))
+						      (define set4 (set number-comparator 1 2 3 4))
+						      (define setx (set number-comparator 10 20 30 40))
+						      (test-assert (set=? set2 other-set2))
+						      (test-assert (not (set=? set2 set3)))
+						      (test-assert (not (set=? set2 set3 other-set2)))
+						      (test-assert (set<? set2 set3 set4))
+						      (test-assert (not (set<? set2 other-set2)))
+						      (test-assert (set<=? set2 other-set2 set3))
+						      (test-assert (not (set<=? set2 set3 other-set2)))
+						      (test-assert (set>? set4 set3 set2))
+						      (test-assert (not (set>? set2 other-set2)))
+						      (test-assert (set>=? set3 other-set2 set2))
+						      (test-assert (not (set>=? other-set2 set3 set2)))
+						      ) ; end sets/subsets
+
+					  (test-group "sets/ops"
+						      ;; Potentially mutable
+						      (define abcd (set eq-comparator 'a 'b 'c 'd))
+						      (define efgh (set eq-comparator 'e 'f 'g 'h))
+						      (define abgh (set eq-comparator 'a 'b 'g 'h))
+						      ;; Never get a chance to be mutated
+						      (define other-abcd (set eq-comparator 'a 'b 'c 'd))
+						      (define other-efgh (set eq-comparator 'e 'f 'g 'h))
+						      (define other-abgh (set eq-comparator 'a 'b 'g 'h))
+						      (define all (set eq-comparator 'a 'b 'c 'd 'e 'f 'g 'h))
+						      (define none (set eq-comparator))
+						      (define ab (set eq-comparator 'a 'b))
+						      (define cd (set eq-comparator 'c 'd))
+						      (define ef (set eq-comparator 'e 'f))
+						      (define gh (set eq-comparator 'g 'h))
+						      (define cdgh (set eq-comparator 'c 'd 'g 'h))
+						      (define abcdgh (set eq-comparator 'a 'b 'c 'd 'g 'h))
+						      (define abefgh (set eq-comparator 'a 'b 'e 'f 'g 'h))
+						      (test-assert (set-disjoint? abcd efgh))
+						      (test-assert (not (set-disjoint? abcd ab)))
+						      (parameterize ((current-test-comparator set=?))
+							(define efgh2 (set-copy efgh))
+							(define abcd2 (set-copy abcd))
+							(define abcd3 (set-copy abcd))
+							(define abcd4 (set-copy abcd))
+							(test all (set-union abcd efgh))
+							(test abcdgh (set-union abcd abgh))
+							(set! efgh2 (set-union! efgh2 abgh))
+							(test abefgh (set-union efgh abgh))
+							(test abefgh efgh2)
+							(test none (set-intersection abcd efgh))
+							(set! abcd2 (set-intersection! abcd2 efgh))
+							(test none abcd2)
+							(test ab (set-intersection abcd abgh))
+							(test ab (set-intersection abgh abcd))
+							(test cd (set-difference abcd ab))
+							(test abcd (set-difference abcd gh))
+							(test none (set-difference abcd abcd))
+							(set! abcd3 (set-difference! abcd3 abcd))
+							(test none abcd3)
+							(test cdgh (set-xor abcd abgh))
+							(test all (set-xor abcd efgh))
+							(test none (set-xor abcd other-abcd))
+							;; don't test-eq xor! effect
+							(test none (set-xor! abcd4 other-abcd))
+							(test "abcd smashed?" other-abcd abcd)
+							(test "efgh smashed?" other-efgh efgh)
+							(test "abgh smashed?" other-abgh abgh))
+						      ) ; end sets/subsets
+
+					  (test-group "sets/mismatch"
+						      (define nums (set number-comparator 1 2 3))
+						      (define syms (set eq-comparator 'a 'b 'c))
+						      (test-error (set=? nums syms))
+						      (test-error (set<? nums syms))
+						      (test-error (set<=? nums syms))
+						      (test-error (set>? nums syms))
+						      (test-error (set>=? nums syms))
+						      (test-error (set-union nums syms))
+						      (test-error (set-intersection nums syms))
+						      (test-error (set-difference nums syms))
+						      (test-error (set-xor nums syms))
+						      (test-error (set-union! nums syms))
+						      (test-error (set-intersection! nums syms))
+						      (test-error (set-difference! nums syms))
+						      (test-error (set-xor! nums syms))
+						      ) ; end sets/mismatch
+
+					  (test-group "sets/whole"
+						      (define whole (set eqv-comparator 1 2 3 4 5 6 7 8 9 10))
+						      (define whole2 (set-copy whole))
+						      (define whole3 (set-copy whole))
+						      (define whole4 (set-copy whole))
+						      (define bottom (set eqv-comparator 1 2 3 4 5))
+						      (define top (set eqv-comparator 6 7 8 9 10))
+						      (define hetero (set eqv-comparator 1 2 'a 3 4))
+						      (define homo (set eqv-comparator 1 2 3 4 5))
+						      (define-values (topx bottomx)
+							(set-partition big whole))
+						      (define-values (whole4 bottomy) (set-partition! big whole4))
+						      (parameterize ((current-test-comparator set=?))
+							(test top (set-filter big whole))
+							(test bottom (set-remove big whole))
+							(set! whole2 (set-filter! big whole2))
+							(test-assert (not (set-contains? whole2 1)))
+							(set! whole3 (set-remove! big whole3))
+							(test-assert (not (set-contains? whole3 10)))
+							(test top topx)
+							(test bottom bottomx)
+							(test top whole4))
+						      (test-eq 5 (set-count big whole))
+						      (test-eq 'a (set-find symbol? hetero (lambda () (error "wrong"))))
+						      (test-error  (set-find symbol? homo (lambda () (error "wrong"))))
+						      (test-assert (set-any? symbol? hetero))
+						      (test-assert (set-any? number? hetero))
+						      (test-assert (not (set-every? symbol? hetero)))
+						      (test-assert (not (set-every? number? hetero)))
+						      (test-assert (not (set-any? symbol? homo)))
+						      (test-assert (set-every? number? homo))
+						      ) ; end sets/whole
+
+					  (test-group "sets/lowlevel"
+						      (define bucket (set string-ci-comparator "abc" "def"))
+						      (define nums (set number-comparator 1 2 3))
+						      (define nums2 (set-replace nums 2.0))
+						      (define sos
+							(set set-comparator
+							     (set eqv-comparator 1 2)
+							     (set eqv-comparator 1 2)))
+						      (test-eq string-ci-comparator (set-element-comparator bucket))
+						      (test-assert (set-contains? bucket "abc"))
+						      (test-assert (set-contains? bucket "ABC"))
+						      (test-equal "def" (set-member bucket "DEF" "fqz"))
+						      (test-equal "fqz" (set-member bucket "lmn" "fqz"))
+						      ;; nums is now {1, 2, 3}
+						      ;; nums2 is now {1, 2.0, 3}
+						      (test-assert (set-any? inexact? nums2))
+						      (set! nums (set-replace! nums 2.0))
+						      ;; nums is now {1, 2.0, 3}
+						      (test-assert (set-any? inexact? nums))
+						      (test-eq 1 (set-size sos))
+						      ) ; end sets/lowlevel
+
+					  ) ; end sets
+
+			      (test-group "bags"
+					  (test-group "bags/simple"
+						      (define total 0)
+						      (define nums (bag number-comparator))
+						      ;; nums is now {}
+						      (define syms (bag eq-comparator 'a 'b 'c 'd))
+						      ;; syms is now {a, b, c, d}
+						      (define nums2 (bag-copy nums))
+						      ;; nums2 is now {}
+						      (define syms2 (bag-copy syms))
+						      ;; syms2 is now {a, b, c, d}
+						      (define esyms (bag eq-comparator))
+						      ;; esyms is now {}
+						      (test-assert (bag-empty? esyms))
+						      (test-assert (bag? nums))
+						      (test-assert (bag? syms))
+						      (test-assert (bag? nums2))
+						      (test-assert (bag? syms2))
+						      (test-assert (not (bag? 'a)))
+						      (set! nums (bag-adjoin! nums 2))
+						      (set! nums (bag-adjoin! nums 3))
+						      (set! nums (bag-adjoin! nums 4))
+						      ;; nums is now {2, 3, 4}
+						      (test-eqv 4 (bag-size (bag-adjoin nums 5)))
+						      (test-eqv 3 (bag-size nums))
+						      (test-eqv 3 (bag-size (bag-delete syms 'd)))
+						      (test-eqv 2 (bag-size (bag-delete-all syms '(c d))))
+						      (test-eqv 4 (bag-size syms))
+						      (set! syms (bag-adjoin! syms 'e 'f))
+						      ;; syms is now {a, b, c, d, e, f}
+						      (test-eqv 4 (bag-size (bag-delete-all! syms '(e f))))
+						      ;; syms is now {a, b, c, d}
+						      (test-eqv 3 (bag-size nums))
+						      (set! nums (bag-delete! nums 1))
+						      (test-eqv 3 (bag-size nums))
+						      (set! nums2 (bag-map (lambda (x) (* 10 x)) number-comparator nums))
+						      ;; nums2 is now {20, 30, 40}
+						      (test-assert (bag-contains? nums2 30))
+						      (test-assert (not (bag-contains? nums2 3)))
+						      (bag-for-each (lambda (x) (set! total (+ total x))) nums2)
+						      (test-eqv 90 total)
+						      (test-eqv 12 (bag-fold + 3 nums))
+						      (set! nums (bag eqv-comparator 10 20 30 40 50))
+						      ;; nums is now {10, 20, 30, 40, 50}
+						      (test-assert
+							  (bag=? nums (bag-unfold
+								       (lambda (i) (= i 0))
+								       (lambda (i) (* i 10))
+								       (lambda (i) (- i 1))
+								       5
+								       eqv-comparator)))
+						      (test-equal '(a) (bag->list (bag eq-comparator 'a)))
+						      (set! syms2 (list->bag eq-comparator '(e f)))
+						      ;; syms2 is now {e, f}
+						      (test-eqv 2 (bag-size syms2))
+						      (test-assert (bag-contains? syms2 'e))
+						      (test-assert (bag-contains? syms2 'f))
+						      (set! syms2 (list->bag! syms2 '(e f)))
+						      ;; syms2 is now {e, e, f, f}
+						      (test-eq 4 (bag-size syms2))
+						      ) ; end bags/simple
+
+					  (test-group "bags/search"
+						      (define yam (bag char-comparator #\y #\a #\m))
+						      (define (failure/insert insert ignore)
+							(insert 1))
+						      (define (failure/ignore insert ignore)
+							(ignore 2))
+						      (define (success/update element update remove)
+							(update #\b 3))
+						      (define (success/remove element update remove)
+							(remove 4))
+						      (define yam! (bag char-comparator #\y #\a #\m #\!))
+						      (define bam (bag char-comparator #\b #\a #\m))
+						      (define ym (bag char-comparator #\y #\m))
+						      (define-values (bag1 obj1)
+							(bag-search! (bag-copy yam) #\! failure/insert error))
+						      (define-values (bag2 obj2)
+							(bag-search! (bag-copy yam) #\! failure/ignore error))
+						      (define-values (bag3 obj3)
+							(bag-search! (bag-copy yam) #\y error success/update))
+						      (define-values (bag4 obj4)
+							(bag-search! (bag-copy yam) #\a error success/remove))
+						      (test-assert (bag=? yam! bag1))
+						      (test-eqv 1 obj1)
+						      (test-assert (bag=? yam bag2))
+						      (test-eqv 2 obj2)
+						      (test-assert (bag=? bam bag3))
+						      (test-eqv 3 obj3)
+						      (test-assert (bag=? ym bag4))
+						      (test-eqv 4 obj4)
+						      ) ; end bags/search
+
+					  (test-group "bags/elemcount"
+						      (define mybag (bag eqv-comparator 1 1 1 1 1 2 2))
+						      (test-eqv 5 (bag-element-count mybag 1))
+						      (test-eqv 0 (bag-element-count mybag 3))
+						      ) ; end bags/elemcount
+
+					  (test-group "bags/subbags"
+						      (define bag2 (bag number-comparator 1 2))
+						      (define other-bag2 (bag number-comparator 1 2))
+						      (define bag3 (bag number-comparator 1 2 3))
+						      (define bag4 (bag number-comparator 1 2 3 4))
+						      (define bagx (bag number-comparator 10 20 30 40))
+						      (test-assert (bag=? bag2 other-bag2))
+						      (test-assert (not (bag=? bag2 bag3)))
+						      (test-assert (not (bag=? bag2 bag3 other-bag2)))
+						      (test-assert (bag<? bag2 bag3 bag4))
+						      (test-assert (not (bag<? bag2 other-bag2)))
+						      (test-assert (bag<=? bag2 other-bag2 bag3))
+						      (test-assert (not (bag<=? bag2 bag3 other-bag2)))
+						      (test-assert (bag>? bag4 bag3 bag2))
+						      (test-assert (not (bag>? bag2 other-bag2)))
+						      (test-assert (bag>=? bag3 other-bag2 bag2))
+						      (test-assert (not (bag>=? other-bag2 bag3 bag2)))
+						      ) ; end bags/subbags
+
+					  (test-group "bags/multi"
+						      (define one (bag eqv-comparator 10))
+						      (define two (bag eqv-comparator 10 10))
+						      (test-assert (not (bag=? one two)))
+						      (test-assert (bag<? one two))
+						      (test-assert (not (bag>? one two)))
+						      (test-assert (bag<=? one two))
+						      (test-assert (not (bag>? one two)))
+						      (test-assert (bag=? two two))
+						      (test-assert (not (bag<? two two)))
+						      (test-assert (not (bag>? two two)))
+						      (test-assert (bag<=? two two))
+						      (test-assert (bag>=? two two))
+						      (test-equal '((10 . 2))
+							(let ((result '()))
+							  (bag-for-each-unique
+							   (lambda (x y) (set! result (cons (cons x y) result)))
+							   two)
+							  result))
+						      (test-eqv 25 (bag-fold + 5 two))
+						      (test-eqv 12 (bag-fold-unique (lambda (k n r) (+ k n r)) 0 two))
+						      ) ; end bags/multi
+
+					  (test-group "bags/ops"
+						      ;; Potentially mutable
+						      (define abcd (bag eq-comparator 'a 'b 'c 'd))
+						      (define efgh (bag eq-comparator 'e 'f 'g 'h))
+						      (define abgh (bag eq-comparator 'a 'b 'g 'h))
+						      ;; Never get a chance to be mutated
+						      (define other-abcd (bag eq-comparator 'a 'b 'c 'd))
+						      (define other-efgh (bag eq-comparator 'e 'f 'g 'h))
+						      (define other-abgh (bag eq-comparator 'a 'b 'g 'h))
+						      (define all (bag eq-comparator 'a 'b 'c 'd 'e 'f 'g 'h))
+						      (define none (bag eq-comparator))
+						      (define ab (bag eq-comparator 'a 'b))
+						      (define cd (bag eq-comparator 'c 'd))
+						      (define ef (bag eq-comparator 'e 'f))
+						      (define gh (bag eq-comparator 'g 'h))
+						      (define cdgh (bag eq-comparator 'c 'd 'g 'h))
+						      (define abcdgh (bag eq-comparator 'a 'b 'c 'd 'g 'h))
+						      (define abefgh (bag eq-comparator 'a 'b 'e 'f 'g 'h))
+						      (test-assert (bag-disjoint? abcd efgh))
+						      (test-assert (not (bag-disjoint? abcd ab)))
+						      (parameterize ((current-test-comparator bag=?))
+							(define efgh2 (bag-copy efgh))
+							(define abcd2 (bag-copy abcd))
+							(define abcd3 (bag-copy abcd))
+							(define abcd4 (bag-copy abcd))
+							(define abab (bag eq-comparator 'a 'b 'a 'b))
+							(define ab2 (bag-copy ab))
+							(define ab3 (bag-copy ab))
+							(test all (bag-union abcd efgh))
+							(test abcdgh (bag-union abcd abgh))
+							(test abefgh (bag-union efgh abgh))
+							(set! efgh2 (bag-union! efgh2 abgh))
+							(test abefgh efgh2)
+							(test none (bag-intersection abcd efgh))
+							(set! abcd2 (bag-intersection! abcd2 efgh))
+							(test none abcd2)
+							(test ab (bag-intersection abcd abgh))
+							(test ab (bag-intersection abgh abcd))
+							(test cd (bag-difference abcd ab))
+							(test abcd (bag-difference abcd gh))
+							(test none (bag-difference abcd abcd))
+							(set! abcd3 (bag-difference! abcd3 abcd))
+							(test none abcd3)
+							(test cdgh (bag-xor abcd abgh))
+							(test all (bag-xor abcd efgh))
+							(test none (bag-xor abcd other-abcd))
+							(test none (bag-xor! abcd4 other-abcd))
+							(test abab (bag-sum! ab2 ab))
+							(test-skip 1)
+							(test abab ab2)
+							(test abab (bag-product 2 ab))
+							(set! ab3 (bag-product! 2 ab3))
+							(test abab ab3)
+							(test "abcd smashed?" other-abcd abcd)
+							(test "abcd smashed?" other-abcd abcd)
+							(test "efgh smashed?" other-efgh efgh)
+							(test "abgh smashed?" other-abgh abgh))
+						      ) ; end bags/ops
+
+					  (test-group "bags/mismatch"
+						      (define nums (bag number-comparator 1 2 3))
+						      (define syms (bag eq-comparator 'a 'b 'c))
+						      (test-error (bag=? nums syms))
+						      (test-error (bag<? nums syms))
+						      (test-error (bag<=? nums syms))
+						      (test-error (bag>? nums syms))
+						      (test-error (bag>=? nums syms))
+						      (test-error (bag-union nums syms))
+						      (test-error (bag-intersection nums syms))
+						      (test-error (bag-difference nums syms))
+						      (test-error (bag-xor nums syms))
+						      (test-error (bag-union! nums syms))
+						      (test-error (bag-intersection! nums syms))
+						      (test-error (bag-difference! nums syms))
+						      ) ; end bags/mismatch
+
+					  (test-group "bags/whole"
+						      (define whole (bag eqv-comparator 1 2 3 4 5 6 7 8 9 10))
+						      (define whole2 (bag-copy whole))
+						      (define whole3 (bag-copy whole))
+						      (define whole4 (bag-copy whole))
+						      (define bottom (bag eqv-comparator 1 2 3 4 5))
+						      (define top (bag eqv-comparator 6 7 8 9 10))
+						      (define-values (topx bottomx)
+							(bag-partition big whole))
+						      (define hetero (bag eqv-comparator 1 2 'a 3 4))
+						      (define homo (bag eqv-comparator 1 2 3 4 5))
+						      (define-values (whole4 bottomy)
+							(bag-partition! big whole4))
+						      (parameterize ((current-test-comparator bag=?))
+							(test top (bag-filter big whole))
+							(test bottom (bag-remove big whole))
+							(set! whole2 (bag-filter! big whole2))
+							(test-assert (not (bag-contains? whole2 1)))
+							(set! whole3 (bag-remove! big whole3))
+							(test-assert (not (bag-contains? whole3 10)))
+							(test top topx)
+							(test bottom bottomx)
+							(test top whole4))
+						      (test-eqv 5 (bag-count big whole))
+						      (test-eq 'a (bag-find symbol? hetero (lambda () (error "wrong"))))
+						      (test-error  (bag-find symbol? homo (lambda () (error "wrong"))))
+						      (test-assert (bag-any? symbol? hetero))
+						      (test-assert (bag-any? number? hetero))
+						      (test-assert (not (bag-every? symbol? hetero)))
+						      (test-assert (not (bag-every? number? hetero)))
+						      (test-assert (not (bag-any? symbol? homo)))
+						      (test-assert (bag-every? number? homo))
+						      ) ; end bags/whole
+
+					  (test-group "bags/lowlevel"
+						      (define bucket (bag string-ci-comparator "abc" "def"))
+						      (define nums (bag number-comparator 1 2 3))
+						      ;; nums is now {1, 2, 3}
+						      (define nums2 (bag-replace nums 2.0))
+						      ;; nums2 is now {1, 2.0, 3}
+						      (define bob
+							(bag bag-comparator
+							     (bag eqv-comparator 1 2)
+							     (bag eqv-comparator 1 2)))
+						      (test-eq string-ci-comparator (bag-element-comparator bucket))
+						      (test-assert (bag-contains? bucket "abc"))
+						      (test-assert (bag-contains? bucket "ABC"))
+						      (test-equal "def" (bag-member bucket "DEF" "fqz"))
+						      (test-equal "fqz" (bag-member bucket "lmn" "fqz"))
+						      (test-assert (bag-any? inexact? nums2))
+						      (set! nums (bag-replace! nums 2.0))
+						      ;; nums is now {1, 2.0, 3}
+						      (test-assert (bag-any? inexact? nums))
+						      (test-eqv 2 (bag-size bob))
+						      ) ; end bags/lowlevel
+
+
+					  (test-group "bags/semantics"
+						      (define mybag (bag number-comparator 1 2))
+						      ;; mybag is {1, 2}
+						      (test-eqv 2 (bag-size mybag))
+						      (set! mybag (bag-adjoin! mybag 1))
+						      ;; mybag is {1, 1, 2}
+						      (test-eqv 3 (bag-size mybag))
+						      (test-eqv 2 (bag-unique-size mybag))
+						      (set! mybag (bag-delete! mybag 2))
+						      ;; mybag is {1, 1}
+						      (set! mybag (bag-delete! mybag 2))
+						      (test-eqv 2 (bag-size mybag))
+						      (set! mybag (bag-increment! mybag 1 3))
+						      ;; mybag is {1, 1, 1, 1, 1}
+						      (test-eqv 5 (bag-size mybag))
+						      (set! mybag (bag-decrement! mybag 1 2))
+						      (test-assert mybag)
+						      ;; mybag is {1, 1, 1}
+						      (test-eqv 3 (bag-size mybag))
+						      (set! mybag (bag-decrement! mybag 1 5))
+						      ;; mybag is {}
+						      (test-eqv 0 (bag-size mybag))
+						      ) ; end bags/semantics
+
+					  (test-group "bags/convert"
+						      (define multi (bag eqv-comparator 1 2 2 3 3 3))
+						      (define single (bag eqv-comparator 1 2 3))
+						      (define singleset (set eqv-comparator 1 2 3))
+						      (define minibag (bag eqv-comparator 'a 'a))
+						      (define alist '((a . 2)))
+						      (test-equal alist (bag->alist minibag))
+						      (test-assert (bag=? minibag (alist->bag eqv-comparator alist)))
+						      (test-assert (set=? singleset (bag->set single)))
+						      (test-assert (set=? singleset (bag->set multi)))
+						      (test-assert (bag=? single (set->bag singleset)))
+						      (test-assert (not (bag=? multi (set->bag singleset))))
+						      (set! minibag (set->bag! minibag singleset))
+						      ;; minibag is now {a, a, a, a, 1, 2, 3}
+						      (test-assert (bag-contains? minibag 1))
+						      ) ; end bags/convert
+
+					  (test-group "bags/sumprod"
+						      (define abb (bag eq-comparator 'a 'b 'b))
+						      (define aab (bag eq-comparator 'a 'a 'b))
+						      (define total (bag-sum abb aab))
+						      (define bag1 (bag eqv-comparator 1))
+						      (test-eqv 3 (bag-count (lambda (x) (eqv? x 'a)) total))
+						      (test-eqv 3 (bag-count (lambda (x) (eqv? x 'b)) total))
+						      (test-eqv 12 (bag-size (bag-product 2 total)))
+						      (set! bag1 (bag-sum! bag1 bag1))
+						      (test-eqv 2 (bag-size bag1))
+						      (set! bag1 (bag-product! 2 bag1))
+						      (test-eqv 4 (bag-size bag1))
+						      ) ; end bag/sumprod
+
+					  ) ; end bags
+			      )
+
+		  (test-group "comparators"
+			      (define a (set number-comparator 1 2 3))
+			      (define b (set number-comparator 1 2 4))
+			      (define aa (bag number-comparator 1 2 3))
+			      (define bb (bag number-comparator 1 2 4))
+			      (test-assert (not (=? set-comparator a b)))
+			      (test-assert (=? set-comparator a (set-copy a)))
+			      (test-skip 1)
+			      (test-error (<? set-comparator a b))
+			      (test-assert (not (=? bag-comparator aa bb)))
+			      (test-assert (=? bag-comparator aa (bag-copy aa)))
+			      (test-skip 1)
+			      (test-error (<? bag-comparator aa bb))
+			      (test-assert (not (=? default-comparator a aa)))
+			      )		; end comparators
+		  )
+
+	
+
+      (test-end))))

--- a/srfi/145.scm
+++ b/srfi/145.scm
@@ -22,6 +22,10 @@
 
 (define-syntax assume
   (syntax-rules ()
+    ((assume (t x))
+     (unless (t x)
+       (fatal-error "invalid assumption" (quote (t x)) x)))
+
     ((assume expression)
      (unless expression
        (fatal-error "invalid assumption" (quote expression))))

--- a/srfi/146.scm
+++ b/srfi/146.scm
@@ -106,14 +106,14 @@
      (assume (mapping? mapping))
      (assume (procedure? failure))
      (assume (procedure? success))
-     (call/cc
-      (lambda (return)
-	(mapping-search mapping
-		    key
-		    (lambda (insert ignore)
-		      (return (failure)))
-		    (lambda (key value update remove)
-		      (return (success value)))))))))
+     ((call/cc
+       (lambda (return-thunk)
+	 (mapping-search mapping
+			 key
+			 (lambda (insert ignore)
+			   (return-thunk failure))
+			 (lambda (key value update remove)
+			   (return-thunk (lambda () (success value)))))))))))
 
 (define (mapping-ref/default mapping key default)
   (assume (mapping? mapping))

--- a/srfi/146.scm
+++ b/srfi/146.scm
@@ -179,7 +179,7 @@
 		 (lambda (insert ignore)
 		   (receive (value)
 		       (failure)
-		     (insert key value value)))
+		     (insert value value)))
 		 (lambda (old-key old-value update remove)
 		   (return mapping old-value))))))
 
@@ -202,7 +202,7 @@
 	(mapping-search mapping
 		    key
 		    (lambda (insert ignore)
-		      (insert key (updater (failure)) #f))
+		      (insert (updater (failure)) #f))
 		    (lambda (old-key old-value update remove)
 		      (update key (updater (success old-value)) #f)))
       mapping))))
@@ -228,7 +228,8 @@
 			(mapping-tree mapping)
 			key
 			(lambda (insert ignore)
-			  (failure insert
+			  (failure (lambda (value obj)
+				     (insert key value obj))
 				   (lambda (obj)
 				     (return mapping obj))))
 			success)))
@@ -451,7 +452,7 @@
 	    #f)
 	   ((less? key2 key1)
 	    (loop item1 (gen2)))
-	   ((equality-predicate item1 item2)
+	   ((equality-predicate value1 value2)
 	    (loop (gen1) (gen2)))
 	   (else
 	    #f))))))))
@@ -529,15 +530,15 @@
 
 (define (%mapping-union mapping1 mapping2)
   (mapping-fold (lambda (key2 value2 mapping)
-	      (receive (mapping obj)
-		  (mapping-search mapping
-			      key2
-			      (lambda (insert ignore)
-				(insert key2 value2 #f))
-			      (lambda (key1 value1 update remove)
-				(update key1 value1 #f)))
-		mapping))
-	    mapping1 mapping2))
+		  (receive (mapping obj)
+		      (mapping-search mapping
+				      key2
+				      (lambda (insert ignore)
+					(insert value2 #f))
+				      (lambda (key1 value1 update remove)
+					(update key1 value1 #f)))
+		    mapping))
+		mapping1 mapping2))
 
 (define (%mapping-intersection mapping1 mapping2)
   (mapping-filter (lambda (key1 value1)
@@ -562,7 +563,7 @@
 		  (mapping-search mapping
 			      key2
 			      (lambda (insert ignore)
-				(insert key2 value2 #f))
+				(insert value2 #f))
 			      (lambda (key1 value1 update remove)
 				(remove #f)))
 		mapping))

--- a/srfi/146/test.sld
+++ b/srfi/146/test.sld
@@ -1,4 +1,5 @@
-;; Copyright (C) Marc Nieper-Wißkirchen (2016).  All Rights Reserved. 
+;; Copyright (C) Marc Nieper-Wißkirchen (2016, 2017).  All Rights
+;; Reserved.
 
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation

--- a/tests.scm
+++ b/tests.scm
@@ -20,6 +20,8 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
-(import (rename (srfi 146 test) (run-tests run-srfi-146-tests)))
+(import (rename (srfi 146 test) (run-tests run-srfi-146-tests))
+	(rename (srfi 113 test) (run-tests run-srfi-113-tests)))
 
 (run-srfi-146-tests)
+(run-srfi-113-tests)


### PR DESCRIPTION
The main change is the addition of an implementation of SRFI 113 ("sets and bags") in terms of the mappings of SRFI 146. This is to demonstrate the usability of the interface of SRFI 146, to have an implementation of SRFI 113 based on comparators with ordering instead of hash procedures, and to have the base for an implementation for ordered sets and bags for a future SRFI.

Other changes include some code fixes in the SRFI 146 code, and adding the requirement to invoking the failure and success procedures in tail context when viable.
