### PR TITLE
New draft with all improvements that were agreed upon

### DIFF
--- a/srfi-146.html
+++ b/srfi-146.html
@@ -97,9 +97,9 @@ explicitly deal with sets of associations.
 
 <p>
   Mappings form a new type as if created
-  by <code>define-record-type</code>.  It is an error to use
-  record-type inspection or inheritance on the mapping type; <i>i.e.</i> the
-  mapping type is sealed and opaque in the language of SRFI 99.
+  by <code>define-record-type</code>.  The effect of using record-type
+  inspection or inheritance for the mapping type is
+  unspecified.
 </p>
 
 <p>
@@ -347,13 +347,15 @@ example, <code>mapping-copy</code> could be a no-op.</p>
 
 <p><code>(mapping <em>comparator</em> <em>arg</em> ...)</code></p>
 
-<p>Returns a newly allocated mapping.  The <em>comparator</em> argument is
+<p>Returns a newly allocated mapping.  The <em>comparator</em>
+argument is
 a <a href="http://srfi.schemers.org/srfi-128/srfi-128.html">SRFI
 128</a> comparator, which is used to control and distinguish the keys
-of the mapping.  The <code><em>arg</em></code>s alternate between keys and values and are
-used to initialize the mapping.  In particular, the number
-of <code><em>arg</em></code>s has to be even.  Earlier associations
-with equal keys take precedence over later arguments.</p>
+of the mapping.  The <code><em>arg</em></code>s alternate between keys
+and values and are used to initialize the mapping.  In particular, the
+number of <code><em>arg</em></code>s has to be even.  Earlier
+associations with equal keys take precedence over later arguments.
+</p>
 
 <p><code>(mapping-unfold <em>stop?</em> <em>mapper</em> <em>successor</em> <em>seed</em> <em>comparator</em>)</code></p>
 
@@ -366,6 +368,13 @@ with equal keys take precedence over later arguments.</p>
   procedure <em>successor</em> to <em>seed</em>, and repeat this
   algorithm.  Associations earlier in the list take precedence over those that come later.
 </p>
+
+<p><i>Note that the choice of precedence in <code>mapping</code> and <code>mapping-unfold</code>
+    is compatible
+    with <code>mapping-adjoin</code> and <code>alist->mapping</code>
+    detailed below and with <code>alist-&gt;hash-table</code> from SRFI
+    125, but different from the one in <code>mapping-set</code> from below.
+</i></p>
 
 <p><code>(mapping/ordered <em>comparator</em> <em>arg</em> ...)</code></p>
 
@@ -431,6 +440,29 @@ Semantically equivalent to, but may be more efficient than, the following code:
 <p>Returns the comparator used to compare the keys of the mapping <em>mapping</em>.</p>
 
 <h2 id="Updaters">Updaters</h2>
+
+<p><code>(mapping-adjoin <em>mapping</em> <em>arg</em> ...)</code></p>
+
+<p>The <code>mapping-set</code> procedure returns a newly allocated
+  mapping that uses the same comparator as the
+  mapping <code><em>mapping</em></code> and contains all the
+  associations of <code><em>mapping</em></code>, and in addition new
+  associations by processing the arguments from left to
+  right. The <code><em>arg</em></code>s alternate between keys and
+  values.  Whenever there is a previous association for a key, the
+  previous association prevails and the new associating is skipped.
+  It is an error to add an element to <code><em>mapping</em></code>
+  that does not return <code>#t</code> when passed to the type test
+  procedure of the comparator.
+</p>
+
+<p><code>(mapping-adjoin! <em>mapping</em> <em>arg</em> ...)</code></p>
+
+<p>The <code>mapping-adjoin!</code> procedure is the same
+  as <code>mapping-adjoin</code>, except that it is permitted to mutate and
+  return the <code><em>mapping</em></code> argument rather than allocating
+  a new mapping.
+</p>
 
 <p><code>(mapping-set <em>mapping</em> <em>arg</em> ...)</code></p>
 

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -96,9 +96,10 @@ explicitly deal with sets of associations.
 <h1>Specification</h1>
 
 <p>
-  Mappings are disjoint at least from those types of Scheme objects
-  that were in existence when this library was loaded for the first
-  time.
+  Mappings form a new type as if created
+  by <code>define-record-type</code>.  It is an error to use
+  record-type inspection or inheritance on the mapping type; <i>i.e.</i> the
+  mapping type is sealed and opaque in the language of SRFI 99.
 </p>
 
 <p>

--- a/srfi/146.scm
+++ b/srfi/146.scm
@@ -47,6 +47,9 @@
 	      args
 	      comparator))
 
+;; FIXME: mapping-unfold has a different precedence with respect to
+;; duplicate keys to the spec.
+
 (define (mapping-unfold stop? mapper successor seed comparator)
   (assume (procedure? stop?))
   (assume (procedure? mapper))
@@ -61,8 +64,8 @@
 	  (loop (mapping-set mapping key value)
 		(successor seed))))))
 
-(define mapping-ordered mapping-ordered)
-(define mapping-unfold mapping-unfold)
+(define mapping/ordered mapping)
+(define mapping-unfold/ordered mapping-unfold)
 
 ;; Predicates
 

--- a/srfi/146.scm
+++ b/srfi/146.scm
@@ -47,9 +47,6 @@
 	      args
 	      comparator))
 
-;; FIXME: mapping-unfold has a different precedence with respect to
-;; duplicate keys to the spec.
-
 (define (mapping-unfold stop? mapper successor seed comparator)
   (assume (procedure? stop?))
   (assume (procedure? mapper))
@@ -61,7 +58,7 @@
 	mapping
 	(receive (key value)
 	    (mapper seed)
-	  (loop (mapping-set mapping key value)
+	  (loop (mapping-adjoin mapping key value)
 		(successor seed))))))
 
 (define mapping/ordered mapping)
@@ -126,6 +123,18 @@
   (mapping-ref mapping key (lambda () default)))
 
 ;; Updaters
+
+(define (mapping-adjoin mapping . args)
+  (assume (mapping? mapping))
+  (let loop ((args args)
+	     (mapping mapping))
+    (if (null? args)
+	mapping
+	(receive (mapping value)
+	    (mapping-intern mapping (car args) (lambda () (cadr args)))
+	  (loop (cddr args) mapping)))))
+
+(define mapping-adjoin! mapping-adjoin)
 
 (define (mapping-set mapping . args)
   (assume (mapping? mapping))

--- a/srfi/146.sld
+++ b/srfi/146.sld
@@ -25,7 +25,8 @@
 	  mapping/ordered mapping-unfold/ordered
 	  mapping? mapping-contains? mapping-empty? mapping-disjoint?
 	  mapping-ref mapping-ref/default mapping-key-comparator
-	  mapping-set mapping-set! 
+	  mapping-adjoin mapping-adjoin!
+	  mapping-set mapping-set!
 	  mapping-replace mapping-replace!
 	  mapping-delete mapping-delete! mapping-delete-all mapping-delete-all!
 	  mapping-intern mapping-intern!
@@ -38,7 +39,7 @@
 	  mapping-remove mapping-remove!
 	  mapping-partition mapping-partition!
 	  mapping-copy mapping->alist alist->mapping alist->mapping!
-	  alist->mapping/ordered alist-mapping/ordered!
+	  alist->mapping/ordered alist->mapping/ordered!
 	  mapping=? mapping<? mapping>? mapping<=? mapping>=?
 	  mapping-union mapping-intersection mapping-difference mapping-xor
 	  mapping-union! mapping-intersection! mapping-difference! mapping-xor!

--- a/srfi/146/test.sld
+++ b/srfi/146/test.sld
@@ -98,6 +98,15 @@
 	(define mapping2 (mapping-set mapping1 'c 4 'd 4 'd 5))
 	(define mapping3 (mapping-update mapping1 'b (lambda (x) (* x x))))
 	(define mapping4 (mapping-update/default mapping1 'd (lambda (x) (* x x)) 4))
+	(define mapping5 (mapping-adjoin mapping1 'c 4 'd 4 'd 5))
+
+	(test-equal "mapping-adjoin: key already in mapping"
+	  3
+	  (mapping-ref mapping5 'c))
+
+	(test-equal "mapping-adjoin: key set earlier"
+	  4
+	  (mapping-ref mapping5 'd))
 	
 	(test-equal "mapping-set: key already in mapping"
 	  4
@@ -469,7 +478,7 @@
 	    (comparator? mapping-comparator))
 	  
 	  (test-equal "mapping-keyed mapping"
-	    (list "b" "b" "c" "d" "e")
+	    (list "a" "a" "c" "d" "e")
 	    (list (mapping-ref mapping0 mapping1)
 		  (mapping-ref mapping0 mapping2)
 		  (mapping-ref mapping0 mapping3)


### PR DESCRIPTION
Major changes:

1) New wording on how the uniqueness constraint for the mapping type is to be understood.
2) Added the procedures ‘mapping-adjoin’ and ‘mapping-adjoin!’ mirroring those from SRFI 113 for sets.
3) Emphasized choice of precedence in the constructors ‘mapping’ and ‘mapping-unfold’.