### PR TITLE
Hashmaps, editorial fixes, mapping-pop!

### DIFF
--- a/srfi-146.html
+++ b/srfi-146.html
@@ -1157,7 +1157,7 @@ respect to the natural ordering of the keys.
   Returns a comparator for mappings that is compatible with the equality
   predicate
   <code>(mapping=? <em>comparator</em> <em>mapping<sub>1</sub></em> <em>mapping<sub>2</sub></em>)</code>.
-  These comparators are obliged to provide ordering procedures when
+  The comparator is obliged to provide ordering procedures when
   the implementation of this SRFI requires comparators to provide a
   comparison function, and is obliged to provide hash functions when
   the implementation of this SRFI requires comparators to provide a

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -268,6 +268,7 @@ example, <code>mapping-copy</code> could be a no-op.</p>
       <code>mapping-intern</code>, <code>mapping-intern!</code>,
       <code>mapping-update</code>, <code>mapping-update!</code>,
       <code>mapping-update/default</code>, <code>mapping-update!/default</code>,
+      <code>mapping-pop</code>, <code>mapping-pop!</code>,
       <code>mapping-search</code>, <code>mapping-search!</code></p>
   </li>
 
@@ -433,7 +434,7 @@ The following three procedures, given a key, return the corresponding value.
   itself is return.  If <code><em>key</em></code> is not contained
   in <code><em>mapping</em></code> and <code><em>failure</em></code> is
   supplied, then <code><em>failure</em></code> is invoked in tail context on no
-  arguments and its result is return.  Otherwise, it is an error.
+  arguments and its values are returned.  Otherwise, it is an error.
 </p>
 
 <p><code>(mapping-ref/default <em>mapping</em> <em>key</em> <em>default</em>)</code></p>
@@ -607,6 +608,35 @@ Semantically equivalent to, but may be more efficient than, the following code
   as <code>mapping-update/default</code>, except that it is permitted to mutate and
   return the <code><em>mapping</em></code> argument rather than allocating
   a new mapping.
+</p>
+
+<p><code>(mapping-pop <em>mapping</em> <em>failure</em>)</code></p>
+<p><code>(mapping-pop <em>mapping</em>)</code></p>
+
+<p>The <code>mapping-pop</code> procedure chooses an arbitrary (but
+  see below)
+  association from <code><em>mapping</em></code> and returns three
+  values, a newly allocated mapping that uses the same comparator
+  as <code><em>mapping</em></code> and contains all associations
+  of <code><em>mapping</em></code> except the chosen one, and the key
+  and the value of the chosen association.
+  If <code><em>mapping</em></code> contains no association
+  and <code><em>failure</em></code> is supplied,
+  then <code><em>failure</em></code> is invoked in tail context on no
+  arguments and its values returned.  Otherwise, it is an error.
+</p>
+
+<p>If <code>mapping-pop</code> is imported from <code>(srfi
+    146)</code>, the association with the least key is chosen.
+</p>
+
+<p><code>(mapping-pop! <em>mapping</em> <em>failure</em>)</code></p>
+<p><code>(mapping-pop! <em>mapping</em>)</code></p>
+
+<p>The <code>mapping-pop!</code> procedure is the same
+  as <code>mapping-pop</code>, except that it is permitted to mutate
+  and return the <code><em>mapping</em></code> argument rather than
+  allocating a new mapping.
 </p>
 
 <p><code>(mapping-search <em>mapping</em> <em>key</em> <em>failure</em> <em>success</em>)</code></p>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -946,12 +946,13 @@ earlier in the list take precedence over those that come later.
 and therefore do not constitute a total order on mappings.
 </p>
 
-<p>All predicates in this subsection take
-a <code><em>comparator</em></code> argument, which is a comparator
-used to compare the values of the associations stored in the mappings.
-This comparator is used to define the equality of associations.  Two
-associations are equal if and only if their keys and values are equal,
-respectively.
+<p>
+  All predicates in this subsection take a <code><em>comparator</em></code> argument, which
+  is a comparator used to compare the values of the associations
+  stored in the mappings.  Entries in the mappings are equal if their
+  keys are equal with mappings' key comparator, and their values are
+  equal with the given comparator.  Two associations are equal if and
+  only if their entries are equal, respectively.
 </p>
 
 <p><code>(mapping=? <em>comparator</em> <em>mapping<sub>1</sub></em> <em>mapping<sub>2</sub></em> ...)</code></p>
@@ -1206,9 +1207,9 @@ layer over the procedures of SRFI 146.
 Credit goes to John Cowan for SRFI 113 and SRFI 128, to Will Clinger
 and John Cowan for SRFI 125, and to Kevin Wortman for his
 immutable-maps-proposal.  Special credit also goes to Sudarshan S
-Chawathe for his careful reading of the drafts of this SRFI and his
-many valuable comments which helped to improve this proposal, and to
-Jown Cowan for ideas on ordered mappings.
+Chawathe and Shiro Kawai for their careful readings of the drafts of
+this SRFI and their many valuable comments which helped to improve
+this proposal, and to Jown Cowan for ideas on ordered mappings.
 </p>
 
 <p>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -1098,7 +1098,7 @@ equal to <code><em>obj</em></code>.
   may be more efficient.
 </p>
 
-<p><code>(mapping-catenate <em>mapping</em><sub>1</sub> <em>key</em> <em>value</em>
+<p><code>(mapping-catenate <em>comparator</em> <em>mapping</em><sub>1</sub> <em>key</em> <em>value</em>
     <em>mapping</em></sub>2</sub>)</code></p>
 
 <p>
@@ -1118,8 +1118,8 @@ to the ordering of <code><em>comparator</em></code>.
 
 <p><code>(mapping-catenate! <em>mapping1</em> <em>key</em> <em>value</em> <em>mapping2</em>)</code></p>
 
-<p>The <code>mapping-map/catenate!</code> procedure is the same
-as <code>mapping-map/catenate</code>, except that it is permitted to mutate and
+<p>The <code>mapping-catenate!</code> procedure is the same
+as <code>mapping-catenate</code>, except that it is permitted to mutate and
 return one of the <code><em>mapping</em></code>s rather than allocating a new mapping.
 </p>
 

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -243,7 +243,9 @@ example, <code>mapping-copy</code> could be a no-op.</p>
 
 <ul>
   <li><p><a href="#Constructors">Constructors</a>:
-      <code>mapping</code>, <code>mapping-unfold</code></p>
+      <code>mapping</code>, <code>mapping-unfold</code>,
+      <code>mapping/ordered</code>, <code>mapping-unfold/ordered</code>
+    </p>
   </li>
 
   <li><p><a href="#Predicates">Predicates</a>:
@@ -258,6 +260,7 @@ example, <code>mapping-copy</code> could be a no-op.</p>
   </li>
 
   <li><p><a href="#Updaters">Updaters</a>:
+      <code>mapping-adjoin</code>, <code>mapping-adjoin!</code>,
       <code>mapping-set</code>, <code>mapping-set!</code>,
       <code>mapping-replace</code>, <code>mapping-replace!</code>,
       <code>mapping-delete</code>, <code>mapping-delete!</code>,

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -449,7 +449,7 @@ Semantically equivalent to, but may be more efficient than, the following code:
 
 <p><code>(mapping-adjoin <em>mapping</em> <em>arg</em> ...)</code></p>
 
-<p>The <code>mapping-set</code> procedure returns a newly allocated
+<p>The <code>mapping-adjoin</code> procedure returns a newly allocated
   mapping that uses the same comparator as the
   mapping <code><em>mapping</em></code> and contains all the
   associations of <code><em>mapping</em></code>, and in addition new

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -202,41 +202,40 @@ example, <code>mapping-copy</code> could be a no-op.</p>
 
 <h2>Comparator restrictions</h2>
 
-<p>This SRFI requires comparators to provide a comparison function.
-  However, any implementation may also provide the optional
-  library <code>(srfi 146 hash)</code> which implements essentially
-  the same interface (see below) as <code>(srfi 146)</code> but
-  requires comparators to provide a hash function instead of a
-  comparison function, unless the equality predicate of the comparator
+<p>The library <code>(srfi 146)</code> described in this SRFI requires
+  comparators to provide a comparison function.  Any
+  implementation shall also provide the library <code>(srfi 146
+  hash)</code> which implements essentially the same interface (see
+  below) as <code>(srfi 146)</code> but requires comparators to
+  provide a hash function instead of a comparison function, unless the
+  equality predicate of the comparator
   is <code>eq?</code>, <code>eqv?</code>, <code>equal?</code>, <code>string=?</code>,
   or <code>string-ci=?</code>.
 </p>
 
 <p>
-  The optional library <code>(srfi 146 hash)</code> exports exactly
-  the same identifiers except for those bound to locations which make
-  no sense when a comparison function is absent
-  (e.g. <code>mapping-split</code>).  Should <code>(srfi 146)</code>
-  once be known as <code>(scheme mapping)</code>, the optional library
-  <code>(srfi 146 hash)</code> will get the alternative name <code>(scheme mapping hash)</code>.
+  The library <code>(srfi 146 hash)</code> exports exactly the same
+  identifiers (up to a simple prefix-replacing textual substitution as
+  described in the next paragraph), except for
+  those bound to locations which make no sense when a comparison
+  function is absent (e.g. <code>mapping-split</code>).
+  Should <code>(srfi 146)</code> once become known as <code>(scheme
+  mapping)</code>, it is recommanded that the library
+  <code>(srfi 146 hash)</code> receives the alternative
+  name <code>(scheme hashmap)</code>.
 </p>
 
-<p>
-  Portable Scheme code can discern the availability of mappings with
-  hash functions using <code>cond-expand</code>:
-</p>
-
-<pre>
-  (cond-expand
-    ((library (srfi 146 hash))
-     ...) ; code that sets up comparators with hash functions
-    ((library (srfi 146))
-     ...)) ; code that sets up comparators with ordering procedures
-</pre>
-
-<p>It is left to a future SRFI that will update SRFI 113 to provide an
-  analogous addition to <code>(scheme set)</code>, <em>i.e.</em> to
-  specify <code>(scheme set hash)</code>.
+<p>To make it possible for a program to easily import <code>(srfi
+  146)</code> and <code>(srfi 146 hash)</code> at the same time, the
+  prefix <code>mapping</code> that prefixes the identifiers
+  in <code>(srfi 146)</code> is substituted by <code>hashmap</code>
+  in <code>(srfi 146 hash)</code>.  For example, <code>mapping</code>
+  becomes <code>hashmap</code>, <code>mapping?</code>
+  becomes <code>hashmap?</code>, and <code>mapping-ref</code>
+  becomes <code>hashmap-ref</code>.
+  <code>comparator?</code> remains unchanged.
+  For simplicity, the rest of this
+  SRFI refers to the identifiers by their names in <code>(srfi 146)</code>.
 </p>
 
 <h2 id="index">Index</h2>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -1185,8 +1185,7 @@ on <code>(make-default-comparator)</code>.
 
 <p>
 The sample implementation uses a purely functional data structure and
-is based on red-black trees.  One could easily implement SRFI 113 on
-top of this (or any other) implementation of this SRFI.  The sample
+is based on red-black trees.  The sample
 R7RS implementation is based on SRFI 1, SRFI 2, SRFI 8, SRFI 121, SRFI
 128, and SRFI 145 for which the sample implementations are included in
 the repository.  (Except for SRFI 128, to which the interface proposed
@@ -1195,12 +1194,13 @@ in this SRFI is intimitely tied, the dependencies are trivial.)
 
 <a href="srfi/146.sld">Source for the reference implementation.</a>
 
-<p>For demonstration purposes and to have an implementation for sets
-and bags based on ordered comparators, this SRFI also includes a <a href="srfi/113.sld">new
+<!--
+<p>For demonstration purposes, this SRFI also includes a <a href="srfi/113.sld">new
 implementation of SRFI 113</a> as a thin
 layer over the procedures of SRFI 146.
 </p>
-  
+-->
+
 <h1>Acknowledgements</h1>
 
 <p>

--- a/srfi-146.html
+++ b/srfi-146.html
@@ -1183,6 +1183,10 @@ respect to the natural ordering of the keys.
 
 <h2 id="Comparators">Comparators</h2>
 
+<p><code>(comparator?)</code></p>
+
+<p>Type predicate for comparators as exported by <codee>(srfi 128)</code>.</p>
+
 <p><code>(make-mapping-comparator <em>comparator</em>)</code></p>
 
 <p>

--- a/srfi/146.scm
+++ b/srfi/146.scm
@@ -229,6 +229,23 @@
 
 (define mapping-update!/default mapping-update/default)
 
+(define mapping-pop
+  (case-lambda
+    ((mapping)
+     (mapping-pop mapping (lambda ()
+			    (error "mapping-pop: mapping has no association"))))
+    ((mapping failure)
+     (assume (mapping? mapping))
+     (assume (procedure? failure))
+     ((call/cc
+       (lambda (return-thunk)
+	 (receive (key value)
+	     (mapping-find (lambda (key value) #t) mapping (lambda () (return-thunk failure)))
+	   (lambda ()
+	     (values (mapping-delete mapping key) key value)))))))))
+
+(define mapping-pop! mapping-pop)
+
 (define (mapping-search mapping key failure success)
   (assume (mapping? mapping))
   (assume (procedure? failure))

--- a/srfi/146.sld
+++ b/srfi/146.sld
@@ -31,6 +31,7 @@
 	  mapping-delete mapping-delete! mapping-delete-all mapping-delete-all!
 	  mapping-intern mapping-intern!
 	  mapping-update mapping-update! mapping-update/default mapping-update!/default
+	  mapping-pop mapping-pop!
 	  mapping-search mapping-search!
 	  mapping-size mapping-find mapping-count mapping-any? mapping-every?
 	  mapping-keys mapping-values mapping-entries

--- a/srfi/146.sld
+++ b/srfi/146.sld
@@ -54,7 +54,8 @@
 	  mapping-split
 	  mapping-catenate mapping-catenate!
 	  mapping-map/monotone mapping-map/monotone!
-	  mapping-fold/reverse)
+	  mapping-fold/reverse
+	  comparator?)
   (import (scheme base)
 	  (scheme case-lambda)
 	  (srfi 1)

--- a/srfi/146/test.sld
+++ b/srfi/146/test.sld
@@ -99,6 +99,7 @@
 	(define mapping3 (mapping-update mapping1 'b (lambda (x) (* x x))))
 	(define mapping4 (mapping-update/default mapping1 'd (lambda (x) (* x x)) 4))
 	(define mapping5 (mapping-adjoin mapping1 'c 4 'd 4 'd 5))
+	(define mapping0 (mapping comparator))
 
 	(test-equal "mapping-adjoin: key already in mapping"
 	  3
@@ -150,7 +151,17 @@
 
 	(test-equal "mapping-update/default"
 	  16
-	  (mapping-ref mapping4 'd)))
+	  (mapping-ref mapping4 'd))
+
+	(test-equal "mapping-pop: empty mapping"
+	  'empty
+	  (mapping-pop mapping0 (lambda () 'empty)))
+
+	(test-equal "mapping-pop: non-empty mapping"
+	  (list 2 'a 1)
+	  (receive (mapping key value)
+	      (mapping-pop mapping1)
+	    (list (mapping-size mapping) key value))))
 
       (test-group "The whole mapping"
 	(define mapping0 (mapping comparator))


### PR DESCRIPTION
# Changes

- Editorial fixes (most of them were reported by Shiro Kawai)
- Reference to implementation to SRFI 113 removed because after changes to SRFI 153 it might better become an implementation of SRFI 153
- Added mapping-pop to make the interface as powerful as SRFI 125 (please review the signature of the procedure)
- Prefix the identifiers in `(srfi 146 hash)` with `hashmap`, not `mapping`
- Make `(srfi 146 hash)` mandatory (implementation based on SRFI 125 yet missing)
- Re-export `comparator?` from `(srfi 128)` to define the comparison type (based on my thoughts outlined here: https://groups.google.com/d/msg/scheme-reports-wg2/NZA9CIMRl48/CJ4Xn27CAwAJ)
