### PR TITLE
Reindent one example

### DIFF
--- a/srfi-146.html
+++ b/srfi-146.html
@@ -175,9 +175,10 @@ guaranteed to work:</p>
 
 <pre>
   (let* ((mapping1
-         (mapping (make-default-comparator) 'a 1 'b 2 'c 3)) ; mapping1 = {a&map;1,b&map;2,c&map;3}.
-    (mapping2 (mapping-set! mapping1 'd 4))) ; mapping2 = {a&map;1,b&map;2,c&map;3,d&map;4}
-  mapping1) ; mapping1 = {a&map;1,b&map;2,c&map;3} or mapping1 = {a&map;1,b&map;2,c&map;3;d&map;4} ???
+          (mapping (make-default-comparator) 'a 1 'b 2 'c 3)) ; mapping1 = {a&map;1,b&map;2,c&map;3}.
+         (mapping2
+          (mapping-set! mapping1 'd 4))) ; mapping2 = {a&map;1,b&map;2,c&map;3,d&map;4}
+    mapping1) ; mapping1 = {a&map;1,b&map;2,c&map;3} or mapping1 = {a&map;1,b&map;2,c&map;3;d&map;4} ???
 </pre>
 
 <p>However, this is well-defined:</p>


### PR DESCRIPTION
The current code makes it look like mapping2 is a function call in let's
body while it's just another binding. And the actual body is aligned
with let declaration instead of being indented further in.